### PR TITLE
docs: add bilingual architecture rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ ccRecall/
 │   ├── session-end.mjs           # POST /session/end on SessionEnd
 │   └── README.md                 # Hook installation guide
 ├── docs/
+│   ├── tutorial.md               # End-user walkthrough (install → MCP → usage)
+│   ├── architecture.md           # Daemon design rationale (contributor-oriented)
 │   └── launchd.md                # macOS LaunchAgent install/troubleshoot
 ├── tests/                        # 396 tests across 26 files (parser / scanner /
 │   │                             # summarizer / database / indexer / e2e /

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -237,6 +237,8 @@ ccRecall/
 │   ├── session-end.mjs               # SessionEnd 呼叫 /session/end
 │   └── README.md                     # Hook 安裝指南
 ├── docs/
+│   ├── tutorial_zh.md                # 使用者教學（安裝 → MCP → 日常使用）
+│   ├── architecture_zh.md            # Daemon 設計取捨（給 contributor 看）
 │   └── launchd.md                    # macOS LaunchAgent 安裝/troubleshoot
 ├── tests/                            # 396 個測試橫跨 26 檔案(parser /
 │   │                                 # scanner / summarizer / database /

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,160 @@
+# Architecture — Why the Daemon Looks the Way It Does
+
+> [中文](architecture_zh.md)
+
+This isn't a tutorial. If you want to install ccRecall and use it, read [tutorial.md](tutorial.md). If you're wondering *why* the daemon runs three timers instead of one, why `awaitWriteFinish` is set to 500ms, or why `/session/end` bypasses the watcher it could have reused — you're in the right place.
+
+The source code is the ground truth. Paths like `src/core/watcher.ts:73` point you there. Everything below is the reasoning that didn't fit into code comments.
+
+---
+
+## Three Engines in One Process
+
+When `ccmem` starts, it doesn't spin up one loop — it orchestrates three:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Single process (port 7749)                              │
+│                                                          │
+│  ┌──────────────┐  ┌──────────────┐  ┌────────────┐      │
+│  │ JsonlWatcher │  │ Maintenance  │  │ HTTP/MCP   │      │
+│  │ (event-driven)│ │ Coordinator  │  │ Server     │      │
+│  │              │  │ (5 min tick) │  │ (on-demand)│      │
+│  │ 2s debounce  │  │              │  │            │      │
+│  │ 10min backstop│ │ compression  │  │ harvest    │      │
+│  │ single-flight│  │ single-flight│  │ rescue     │      │
+│  └──────┬───────┘  └──────┬───────┘  └─────┬──────┘      │
+│         │                 │                │              │
+│         └──── SQLite (WAL mode) ←──────────┘              │
+└──────────────────────────────────────────────────────────┘
+```
+
+Each engine has a distinct responsibility, and the `single-flight` guards aren't cosmetic — they exist because contention between them is inevitable under real workloads.
+
+---
+
+## Bootstrap: Why We Await the Initial Index
+
+`src/index.ts:100-148`
+
+The order matters:
+
+1. Open SQLite
+2. **Await** a full `runIndexer(db)`
+3. Start `MaintenanceCoordinator`
+4. Start `JsonlWatcher` (await its `ready` event)
+5. Listen on HTTP
+
+Between step 2 and step 4 there's a race. If you start chokidar with `ignoreInitial: true` *before* your own tree walk finishes, a JSONL written in that window is invisible to both paths. Chokidar skips it (the file was already there when chokidar opened), and the indexer has already moved past that directory. The file stays unseen until the 10-minute backstop fires, or a `/session/end` rescue is triggered for that session.
+
+Awaiting the initial indexer keeps the `ignoreInitial` contract clean: "we already own everything on disk as of now; chokidar, only tell us about changes *after* this moment."
+
+---
+
+## Engine 1: JsonlWatcher
+
+`src/core/watcher.ts`
+
+### The Debounce
+
+Claude Code writes JSONL in streaming bursts — each tool call can fire several `change` events on the same file within milliseconds. Without a debounce, every event triggers `runIndexer`, which does a full tree scan plus N file parses. The debounce collapses a burst into a single scan 2 seconds after the last event settles.
+
+### The Backstop
+
+Debounces can be starved. If a session is very chatty — a tool call every 1.5 seconds for an hour — each event pushes the debounce forward and a scan never fires. That's why the backstop bypasses the debounce entirely:
+
+```ts
+setInterval(() => { void this.runScan() }, this.fullResyncMs)   // 10 min
+```
+
+This isn't a backup for chokidar correctness. Chokidar is mostly reliable, but filesystems have edges — APFS rename races, NFS event loss, symlinks crossing mount points. The backstop is insurance, not redundancy.
+
+### awaitWriteFinish: 500ms
+
+Claude Code keeps a single file handle open across a whole session. A `change` event can fire mid-line — if you `parseSession` while `{"type":"assistant"...` is half-flushed, you get a parse error and drop a valid message. `awaitWriteFinish.stabilityThreshold: 500` means: wait until 500ms pass with no new bytes before considering the file "changed." Long enough to catch mid-write; short enough that it doesn't feel sluggish.
+
+### single-flight
+
+If a scan is running and another event fires, we don't queue it — we set a `dirty` flag and let the current scan finish. Only then do we schedule one follow-up. The queue alternative has a pathological case: scan N, event during N, queue N+1, event during N+1, queue N+2... Under sustained write pressure the work is unbounded.
+
+---
+
+## Engine 2: MaintenanceCoordinator
+
+`src/core/maintenance-coordinator.ts`
+
+Independent 5-minute timer, independent single-flight. Its only job: run `CompressionPipeline.runOnce({ batchSize: 50 })` — age memories, compress them in stages (raw → summary → one-liner), and delete those that haven't been accessed in 60 days.
+
+It does *not* share the watcher's single-flight. Here's why: the watcher writes to `sessions/messages/topics`; the coordinator writes to `memories`. Disjoint tables means they can't corrupt each other's state. What they *can* do is contend for the SQLite writer (WAL serializes one writer at a time), but that's a throughput concern, not a correctness one. Keeping the single-flights per-engine means each one's worst case is bounded by itself, not by the other.
+
+`timer.unref()` — the coordinator's interval does not keep the process alive. The HTTP server is the authoritative keep-alive. This matters in a test harness: when the server closes, the compression timer won't trap the process.
+
+---
+
+## Engine 3: HTTP + the Harvest Endpoint
+
+`src/api/routes.ts`
+
+Memories don't get created by the watcher. The watcher writes **session summaries** (into the `sessions` table); harvesting a summary *into a memory row* happens only when `/session/end` is called. That endpoint is driven by the SessionEnd hook `hooks/session-end.mjs`.
+
+### Why harvest is hook-driven, not watcher-driven
+
+A session's JSONL can grow forever if the user keeps resuming. You don't want to harvest on every file change — you'd produce thousands of duplicate, half-finished memories. You want to harvest exactly once, when the session actually ends. Only Claude Code knows that; hence the hook.
+
+The `reason: 'resume'` filter in `hooks/session-end.mjs:82` is the other half of that contract — a resumed session is *not* an end event, so we skip it. (We suspect this filter is a little too wide in practice — see the harvest-rate gap in the known-limitations section below.)
+
+### rescueReindex: intentional bypass
+
+When the hook fires and the daemon hasn't seen the JSONL yet (fresh-session race: the hook fires before chokidar's `add` event settles), the endpoint calls `rescueReindex` before giving up. Crucially:
+
+```ts
+// src/index.ts:141
+const server = createServer(db, {
+  rescueReindex: () => runIndexer(db),   // NOT watcher.runNow()
+  ...
+})
+```
+
+`watcher.runNow()` would respect the watcher's single-flight — meaning if a scheduled scan is already in flight, the rescue gets silently dropped (just flips `dirty`). That's exactly what we *don't* want for a blocking harvest: the client is waiting on a 200. Calling `runIndexer(db)` directly sidesteps the single-flight and gives the caller deterministic execution.
+
+The tradeoff: two concurrent `runIndexer` runs can contend for the writer. In practice they don't corrupt — SQLite WAL serializes writes — and the window is narrow (rescue only runs on cache miss).
+
+---
+
+## Trade-offs We Chose
+
+| Choice | Alternative | Why |
+|---|---|---|
+| Event-driven + 10min backstop | Pure polling every N seconds | Polling wastes work when idle; pure events miss APFS/NFS edges. Backstop is safety net, not primary path. |
+| Rule-based summarizer (zero LLM) | Call Claude for summaries | Every session would cost money. Rule-based covers the common shape; outliers fall into `discovery` confidence 0.7 and Claude can judge on recall. |
+| Three per-engine single-flights | One global lock | A global lock means compression blocks indexing and vice versa. Per-engine isolates blast radius to its own job. |
+| Hook-driven harvest | Watcher-driven harvest | Only Claude Code knows when a session *really* ends. Watcher sees file writes, not session lifecycle. |
+| Rescue bypasses single-flight | Rescue respects single-flight | Rescue is a blocking HTTP request. Getting dropped silently by the watcher's `dirty` flag would turn into a 404 to the hook. Deterministic execution wins. |
+
+---
+
+## Known Limitations
+
+These are deliberately **not** pinned to values in this doc body — they rot fast. Current state lives elsewhere:
+
+- Open issues: [#11](https://github.com/tznthou/ccRecall/issues/11) (WAL/VACUUM physical compaction), [#13](https://github.com/tznthou/ccRecall/issues/13) (FTS5 CJK edge cases)
+- Harvest-rate gap: we observe a non-trivial fraction of sessions skipped despite having summaries. The prime suspect is the `reason: 'resume'` filter being over-eager; logging the `reason` distribution is on the quick-fix list.
+- Storage governance: the `messages` / `message_archive` / `message_content` / `messages_fts` tables are ccRewind inheritance — an internal audit confirms zero functional loss from dropping them. The migration is planned.
+
+Authoritative state is always `gh issue list` plus project notes, not this file.
+
+---
+
+## Where to Look Next
+
+| Question | File:line |
+|---|---|
+| What does the bootstrap sequence look like? | `src/index.ts:100-148` |
+| How does the watcher decide when to scan? | `src/core/watcher.ts:73-109` |
+| What does runIndexer actually do? | `src/core/indexer.ts:62-262` |
+| How does harvest build a memory from a session? | `src/api/routes.ts:85-99` + `:285-375` |
+| What does the summarizer produce? | `src/core/summarizer.ts:420-480` |
+| Why is `reason: 'resume'` skipped? | `hooks/session-end.mjs:82` |
+| How is compression scheduled? | `src/core/maintenance-coordinator.ts:51-57` |
+
+Found something the doc gets wrong, or a trade-off not explained here? Open a [GitHub Issue](https://github.com/tznthou/ccRecall/issues) — the code is the truth, and this doc should track it.

--- a/docs/architecture_zh.md
+++ b/docs/architecture_zh.md
@@ -1,0 +1,160 @@
+# 架構設計 — daemon 為什麼長這樣
+
+> [English](architecture.md)
+
+這不是 tutorial。想裝 ccRecall 來用請看 [tutorial_zh.md](tutorial_zh.md)。想知道 daemon 為什麼要跑三個 timer 而不是一個、為什麼 `awaitWriteFinish` 要設 500ms、為什麼 `/session/end` 明明可以重用 watcher 卻選擇繞過它——這篇是為你寫的。
+
+Source code 是 truth。像 `src/core/watcher.ts:73` 這種指標帶你直接跳過去看。下面寫的是那些塞不進 code comment 的推論跟取捨。
+
+---
+
+## 一個 process 三個引擎
+
+`ccmem` 啟動時不是開一個 loop——是同時編排三個：
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  同一個 process（port 7749）                              │
+│                                                          │
+│  ┌──────────────┐  ┌──────────────┐  ┌────────────┐      │
+│  │ JsonlWatcher │  │ Maintenance  │  │ HTTP/MCP   │      │
+│  │（事件驅動）  │  │ Coordinator  │  │ Server     │      │
+│  │              │  │（5 分鐘 tick）│ │（需求觸發）│      │
+│  │ 2s debounce  │  │              │  │            │      │
+│  │ 10min backstop│ │ 壓縮排程     │  │ harvest    │      │
+│  │ single-flight│  │ single-flight│  │ rescue     │      │
+│  └──────┬───────┘  └──────┬───────┘  └─────┬──────┘      │
+│         │                 │                │              │
+│         └──── SQLite (WAL 模式) ←──────────┘              │
+└──────────────────────────────────────────────────────────┘
+```
+
+每個引擎職責獨立；那些 `single-flight` guard 不是花拳繡腿——它們必須存在，因為真實負載下衝突無可避免。
+
+---
+
+## Bootstrap：為何要 await 第一次索引
+
+`src/index.ts:100-148`
+
+順序有講究：
+
+1. 開 SQLite
+2. **Await** 完整跑一次 `runIndexer(db)`
+3. 啟動 `MaintenanceCoordinator`
+4. 啟動 `JsonlWatcher`（await 它的 `ready` event）
+5. HTTP listen
+
+Step 2 到 step 4 之間有 race window。如果 chokidar 用 `ignoreInitial: true` 在你自己 tree walk 完成**之前**就起來，那個 window 裡被寫的 JSONL 兩條路都看不到——chokidar 跳過（檔案 chokidar 一開始就在了）、indexer 也已經掃過那個目錄。這檔要嘛等 10 分鐘 backstop，要嘛 `/session/end` rescue 觸發才會被發現。
+
+Await 第一次 indexer 就是讓 `ignoreInitial` 的 contract 乾淨：「目前 disk 上所有東西都由我們掌握；chokidar 啊，只告訴我們**這一刻之後**的變動就好。」
+
+---
+
+## 引擎 1：JsonlWatcher
+
+`src/core/watcher.ts`
+
+### Debounce
+
+Claude Code 寫 JSONL 是流式爆發——每個 tool call 可能在同一檔上毫秒內觸發好幾個 `change` event。沒 debounce 就每 event 跑一次 `runIndexer`，每次都全樹掃 + N 檔 parse。Debounce 把一陣 event 合併成「最後一個 event 後 2 秒跑一次 scan」。
+
+### Backstop
+
+Debounce 會被餓死。如果 session 很愛講話——每 1.5 秒一個 tool call、跑一小時——每個 event 都把 debounce 往後推，scan 永遠輪不到。所以 backstop 直接繞過 debounce：
+
+```ts
+setInterval(() => { void this.runScan() }, this.fullResyncMs)   // 10 min
+```
+
+這不是備援 chokidar 的正確性。Chokidar 大致可靠，但檔案系統有邊角——APFS rename race、NFS event loss、跨 mount 的 symlink。Backstop 是保險，不是冗余。
+
+### awaitWriteFinish: 500ms
+
+Claude Code 整個 session 共用同一個 open file handle 寫 JSONL。`change` event 可能在一行寫到一半時觸發——`{"type":"assistant"...` 才剛 flush 一半你就 parse，parse error 就錯過一筆有效 message。`awaitWriteFinish.stabilityThreshold: 500` 的意思：等 500ms 沒新 byte 才視為「改動完成」。夠長擋得住半寫入，夠短感覺不到遲鈍。
+
+### single-flight
+
+Scan 跑到一半又來 event，我們不 queue——設一個 `dirty` flag 等現在這次跑完，然後只排一次 follow-up。Queue 的替代方案有病態 case：scan N、N 期間來 event、queue N+1、N+1 期間又來 event、queue N+2... 持續寫入壓力下工作量無界。
+
+---
+
+## 引擎 2：MaintenanceCoordinator
+
+`src/core/maintenance-coordinator.ts`
+
+獨立的 5 分鐘 timer、獨立的 single-flight。它只做一件事：跑 `CompressionPipeline.runOnce({ batchSize: 50 })`——讓記憶老化、分階段壓縮（raw → summary → 一行）、60 天沒被 access 就砍。
+
+它**不**共用 watcher 的 single-flight。為什麼：watcher 寫 `sessions/messages/topics`，coordinator 寫 `memories`。兩邊表 disjoint，不會污染彼此 state。唯一可能衝突的是 SQLite writer（WAL 一次一個 writer），但那是吞吐量問題不是正確性問題。每引擎各自 single-flight 就是讓各自最壞 case 只綁自己，不拖累別的引擎。
+
+`timer.unref()`——coordinator 的 interval 不擋 process 存活。HTTP server 才是 authoritative keep-alive。這在測試環境下重要：server close 時壓縮 timer 不會卡死 process。
+
+---
+
+## 引擎 3：HTTP + harvest endpoint
+
+`src/api/routes.ts`
+
+Memory 不是 watcher 建的。Watcher 把 **session summary** 寫進 `sessions` 表；把 summary **升級成 memory row** 只在 `/session/end` 被呼叫時才發生。這 endpoint 由 SessionEnd hook `hooks/session-end.mjs` 觸發。
+
+### 為什麼 harvest 靠 hook 不靠 watcher
+
+Session 的 JSONL 只要使用者一直 resume 就會一直長。你不會想每次檔案變動都 harvest——會產生幾千筆重複或半成品 memory。你要的是「session 真正結束的那一下 harvest 一次」。只有 Claude Code 知道 session 什麼時候真的結束；所以才靠 hook。
+
+`hooks/session-end.mjs:82` 那個 `reason: 'resume'` 的 filter 是 contract 的另一半——resume 不算 end event，跳過。（實際上我們懷疑這個 filter 判太寬——看下面「已知限制」的 harvest rate gap。）
+
+### rescueReindex：刻意繞過
+
+Hook 觸發時 daemon 可能還沒看到那個 JSONL（fresh-session race：hook fire 比 chokidar `add` event 更早），endpoint 會先 `rescueReindex` 再放棄。關鍵：
+
+```ts
+// src/index.ts:141
+const server = createServer(db, {
+  rescueReindex: () => runIndexer(db),   // 不是 watcher.runNow()
+  ...
+})
+```
+
+`watcher.runNow()` 會尊重 watcher 的 single-flight——也就是已經有 scan 在跑時 rescue 會被默默 drop（只翻 `dirty`）。那是我們**不**想要的：client 正在等 200 回來。直接呼 `runIndexer(db)` 繞過 single-flight，給 caller 確定性的執行。
+
+取捨：兩個 `runIndexer` 同時跑可能 writer 爭用。實際上不會 corrupt——SQLite WAL 會 serialize write——而且 window 很窄（rescue 只在 cache miss 時跑）。
+
+---
+
+## 我們選的取捨
+
+| 選擇 | 替代方案 | 為什麼 |
+|---|---|---|
+| 事件驅動 + 10min backstop | 純每 N 秒 polling | 閒置時 polling 浪費工；純事件抓不到 APFS/NFS 邊角。Backstop 是保險不是主線 |
+| Rule-based summarizer（零 LLM）| 呼叫 Claude 做 summary | 每個 session 都燒錢。Rule-based 覆蓋主流形狀；邊角 fallback 到 `discovery` confidence 0.7，Claude recall 時自己判 |
+| 每引擎獨立 single-flight | 一個 global lock | Global lock 會讓壓縮擋索引反之亦然。per-engine 隔離爆炸半徑 |
+| Hook-driven harvest | Watcher-driven harvest | 只有 Claude Code 知道 session 真正什麼時候結束。Watcher 看到的是檔案寫入，不是 session 生命週期 |
+| Rescue 繞 single-flight | Rescue 尊重 single-flight | Rescue 是 blocking HTTP request。被 watcher 的 `dirty` flag 默默吞掉會讓 hook 收到 404。確定執行贏過一致性 |
+
+---
+
+## 已知限制
+
+故意**不**把具體數字寫死在本文——這種東西壞得快。現況請看：
+
+- Open issues：[#11](https://github.com/tznthou/ccRecall/issues/11)（WAL/VACUUM 物理壓縮）、[#13](https://github.com/tznthou/ccRecall/issues/13)（FTS5 CJK edge cases）
+- Harvest rate gap：實際上有非同小可的 session 明明有 summary 卻被跳過。主要嫌疑犯是 `reason: 'resume'` filter 判太寬；log `reason` 分布在 quick-fix 清單
+- Storage governance：`messages` / `message_archive` / `message_content` / `messages_fts` 四表是 ccRewind 基因遺留——內部 audit 證實砍掉零功能損失。Migration 已排上議程
+
+真實狀態永遠以 `gh issue list` + 專案筆記為準，不是本檔。
+
+---
+
+## 要繼續追哪些 source
+
+| 問題 | file:line |
+|---|---|
+| Bootstrap 順序長怎樣 | `src/index.ts:100-148` |
+| Watcher 怎麼決定什麼時候 scan | `src/core/watcher.ts:73-109` |
+| runIndexer 實際做什麼 | `src/core/indexer.ts:62-262` |
+| Harvest 怎麼從 session 組出 memory | `src/api/routes.ts:85-99` + `:285-375` |
+| Summarizer 吐什麼出來 | `src/core/summarizer.ts:420-480` |
+| 為什麼 `reason: 'resume'` 要跳 | `hooks/session-end.mjs:82` |
+| Compression 怎麼排程 | `src/core/maintenance-coordinator.ts:51-57` |
+
+發現本檔寫錯的地方、或某個 trade-off 沒講到？開 [GitHub Issue](https://github.com/tznthou/ccRecall/issues)——code 才是 truth，本檔只該追著它走。

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -271,6 +271,7 @@ The first three steps take ccRecall fully offline. Skip steps 4–5 if you want 
 ## Going Deeper
 
 - **How it works (10-year-old version)**: [`docs/research/ccrecall-for-kids.md`](./research/ccrecall-for-kids.md) — the five-step pipeline explained via a goldfish-friend metaphor
+- **Architecture rationale**: [`docs/architecture.md`](./architecture.md) — why the daemon runs three engines, why `awaitWriteFinish` is 500ms, why `rescueReindex` bypasses the watcher
 - **AI long-term memory design**: [`docs/research/ai-long-term-memory-design.md`](./research/ai-long-term-memory-design.md) — forgetting curve, compression pipeline
 - **Architectural lineage**: [`docs/research/ccrewind-memory-service-architecture.md`](./research/ccrewind-memory-service-architecture.md) — modules extracted from ccRewind
 

--- a/docs/tutorial_zh.md
+++ b/docs/tutorial_zh.md
@@ -273,6 +273,7 @@ ccmem uninstall-hooks
 ## 想深入？
 
 - **十歲版運作原理**：[`docs/research/ccrecall-for-kids.md`](./research/ccrecall-for-kids.md) — 用金魚腦比喻講五步驟
+- **架構設計為什麼長這樣**：[`docs/architecture_zh.md`](./architecture_zh.md) — daemon 為何三引擎並行、`awaitWriteFinish` 為何 500ms、`rescueReindex` 為何繞過 watcher
 - **AI 長期記憶設計**：[`docs/research/ai-long-term-memory-design.md`](./research/ai-long-term-memory-design.md) — 遺忘曲線、壓縮 pipeline
 - **架構源流**：[`docs/research/ccrewind-memory-service-architecture.md`](./research/ccrewind-memory-service-architecture.md) — 從 ccRewind 抽取的模組設計
 


### PR DESCRIPTION
## Summary
- New `docs/architecture.md` + `docs/architecture_zh.md` — bilingual contributor-oriented rationale covering three engines in parallel, bootstrap race, per-engine single-flight isolation, and the intentional `rescueReindex` bypass of `watcher.runNow()`
- Uses `file:line` pointers (e.g. `src/core/watcher.ts:73`) so source code stays authoritative — the doc only records *why*, not *what*
- Wired into tutorial "Going Deeper / 想深入？" sections and the `docs/` trees in both README files

## Why
The design decisions scattered across code comments (bootstrap ordering, `awaitWriteFinish: 500ms`, three independent single-flights, hook-driven vs watcher-driven harvest) were not captured anywhere a curious contributor could land on. This consolidates the rationale without duplicating the mechanics.

## Test plan
- [ ] Verify bilingual cross-links (EN ↔ ZH) render on GitHub
- [ ] Spot-check `file:line` references still match cited locations
- [ ] No source / tests / config touched — no CI impact beyond markdown render

🤖 Generated with [Claude Code](https://claude.com/claude-code)