### PR TITLE
fix: CJK case 5 — LIKE fallback uses AND across short tokens

### DIFF
--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -1363,7 +1363,12 @@ export class Database {
   /** Short-token LIKE fallback for searchSessions. Scans all FTS5-indexed
    *  columns (title, tags, files_touched, summary_text, intent_text) since a
    *  short query could match any of them, and trigram cannot tokenize tokens
-   *  shorter than 3 characters. */
+   *  shorter than 3 characters.
+   *
+   *  Multi-token queries AND each token's per-column OR — every token must
+   *  appear in some column, but tokens may live in different columns (e.g.
+   *  `UI auth` could match a session whose title has UI and whose tags have
+   *  auth). Substring-on-the-whole-query would lose those cross-column hits. */
   private searchSessionsFallback(
     rawQuery: string,
     projectId: string | null | undefined,
@@ -1371,7 +1376,17 @@ export class Database {
     limit: number,
     options: SearchOptions | undefined,
   ): SessionSearchPage {
-    const pattern = Database.likePattern(rawQuery)
+    const tokens = rawQuery.trim().split(/\s+/).filter(Boolean)
+    if (tokens.length === 0) return { results: [], offset, hasMore: false }
+    const patterns = tokens.map(t => Database.likePattern(t))
+    const tokenClause = tokens.map(() => `(
+        s.title LIKE ? ESCAPE '\\'
+        OR s.tags LIKE ? ESCAPE '\\'
+        OR s.files_touched LIKE ? ESCAPE '\\'
+        OR s.summary_text LIKE ? ESCAPE '\\'
+        OR s.intent_text LIKE ? ESCAPE '\\'
+      )`).join(' AND ')
+
     let sql = `
       SELECT
         s.id AS session_id,
@@ -1384,16 +1399,13 @@ export class Database {
         s.outcome_status
       FROM sessions s
       JOIN projects p ON p.id = s.project_id
-      WHERE (
-        s.title LIKE ? ESCAPE '\\'
-        OR s.tags LIKE ? ESCAPE '\\'
-        OR s.files_touched LIKE ? ESCAPE '\\'
-        OR s.summary_text LIKE ? ESCAPE '\\'
-        OR s.intent_text LIKE ? ESCAPE '\\'
-      )
+      WHERE ${tokenClause}
         AND s.id ${Database.EXCLUDE_SUBAGENTS}
     `
-    const params: (string | number | null)[] = [pattern, pattern, pattern, pattern, pattern]
+    const params: (string | number | null)[] = []
+    for (const p of patterns) {
+      params.push(p, p, p, p, p)
+    }
 
     if (projectId) {
       sql += ' AND s.project_id = ?'
@@ -1575,34 +1587,42 @@ export class Database {
 
   /** Short-token LIKE fallback for queryMemories. Trigram tokenizer cannot
    *  match queries shorter than 3 chars; LIKE scans content. EFFECTIVE_CONFIDENCE
-   *  (confidence × decay) replaces FTS5 rank as the primary ordering. */
+   *  (confidence × decay) replaces FTS5 rank as the primary ordering.
+   *
+   *  Multi-token queries (e.g. mixed Latin acronyms + CJK like `UI 記憶`) AND
+   *  each token's LIKE clause so a doc must contain every token somewhere.
+   *  Substring-on-the-whole-query would silently lose `UI 元件設計優化記憶`
+   *  for query `UI 記憶`. */
   private queryMemoriesFallback(
     rawQuery: string,
     limit: number,
     projectId: string | null | undefined,
   ): Memory[] {
-    const pattern = Database.likePattern(rawQuery)
+    const tokens = rawQuery.trim().split(/\s+/).filter(Boolean)
+    if (tokens.length === 0) return []
+    const patterns = tokens.map(t => Database.likePattern(t))
+    const where = tokens.map(() => "m.content LIKE ? ESCAPE '\\'").join(' AND ')
     try {
       const rows = projectId
         ? this.db.prepare(`
             SELECT m.id, m.session_id, m.message_id, m.content, m.type, m.confidence, m.created_at
             FROM memories m
             LEFT JOIN sessions s ON m.session_id = s.id
-            WHERE m.content LIKE ? ESCAPE '\\'
+            WHERE ${where}
               AND (
                 (m.session_id IS NOT NULL AND s.project_id = ?) OR
                 (m.session_id IS NULL AND m.project_id = ?)
               )
             ORDER BY ${Database.EFFECTIVE_CONFIDENCE} DESC, m.created_at DESC, m.id DESC
             LIMIT ?
-          `).all(pattern, projectId, projectId, limit)
+          `).all(...patterns, projectId, projectId, limit)
         : this.db.prepare(`
             SELECT m.id, m.session_id, m.message_id, m.content, m.type, m.confidence, m.created_at
             FROM memories m
-            WHERE m.content LIKE ? ESCAPE '\\'
+            WHERE ${where}
             ORDER BY ${Database.EFFECTIVE_CONFIDENCE} DESC, m.created_at DESC, m.id DESC
             LIMIT ?
-          `).all(pattern, limit)
+          `).all(...patterns, limit)
       return (rows as MemoryRow[]).map(mapMemoryRow)
     } catch (err) {
       console.warn('[memories] queryMemoriesFallback error:', scrubErrorMessage(err))

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -1256,6 +1256,12 @@ export class Database {
 
   static readonly SEARCH_PAGE_SIZE = 30
 
+  /** Cap for short-token LIKE fallback. Each token contributes 1 (memories)
+   *  or 5 (sessions) bind params; an unbounded query would let a caller pass
+   *  N=10000 tokens and stall the event loop in `prepare()` or hit
+   *  SQLITE_MAX_VARIABLE_NUMBER. 20 covers any realistic search query. */
+  private static readonly MAX_FALLBACK_TOKENS = 20
+
   private static readonly VALID_OUTCOMES = new Set(['committed', 'tested', 'in-progress', 'quick-qa'])
   private static parseOutcomeStatus(v: string | null): OutcomeStatus {
     return v && Database.VALID_OUTCOMES.has(v) ? v as OutcomeStatus : null
@@ -1376,7 +1382,7 @@ export class Database {
     limit: number,
     options: SearchOptions | undefined,
   ): SessionSearchPage {
-    const tokens = rawQuery.trim().split(/\s+/).filter(Boolean)
+    const tokens = rawQuery.trim().split(/\s+/).filter(Boolean).slice(0, Database.MAX_FALLBACK_TOKENS)
     if (tokens.length === 0) return { results: [], offset, hasMore: false }
     const patterns = tokens.map(t => Database.likePattern(t))
     const tokenClause = tokens.map(() => `(
@@ -1598,7 +1604,7 @@ export class Database {
     limit: number,
     projectId: string | null | undefined,
   ): Memory[] {
-    const tokens = rawQuery.trim().split(/\s+/).filter(Boolean)
+    const tokens = rawQuery.trim().split(/\s+/).filter(Boolean).slice(0, Database.MAX_FALLBACK_TOKENS)
     if (tokens.length === 0) return []
     const patterns = tokens.map(t => Database.likePattern(t))
     const where = tokens.map(() => "m.content LIKE ? ESCAPE '\\'").join(' AND ')

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -429,6 +429,53 @@ describe('sessions_fts (migration v6)', () => {
     expect(page.results.length).toBeGreaterThanOrEqual(1)
   })
 
+  it('searchSessions LIKE fallback uses AND across short tokens (Case 5)', () => {
+    // `UI` is 2 chars → triggers hasShortToken → falls through to LIKE fallback.
+    // The fallback must AND each token's per-column OR so a session matches
+    // only if every token appears in some column.
+    db.indexSession({
+      sessionId: 'fb-both', projectId: 'proj-fb', projectDisplayName: '/test/fb',
+      title: 'UI 元件改進', messageCount: 0, filePath: '/tmp/fb1.jsonl', fileSize: 0,
+      fileMtime: '2024-01-01T00:00:00.000Z', startedAt: null, endedAt: null,
+      tags: '記憶,refactor', messages: [],
+    })
+    db.indexSession({
+      sessionId: 'fb-ui-only', projectId: 'proj-fb', projectDisplayName: '/test/fb',
+      title: 'Pure UI work', messageCount: 0, filePath: '/tmp/fb2.jsonl', fileSize: 0,
+      fileMtime: '2024-01-01T00:00:00.000Z', startedAt: null, endedAt: null,
+      tags: 'frontend', messages: [],
+    })
+    db.indexSession({
+      sessionId: 'fb-mem-only', projectId: 'proj-fb', projectDisplayName: '/test/fb',
+      title: '記憶系統', messageCount: 0, filePath: '/tmp/fb3.jsonl', fileSize: 0,
+      fileMtime: '2024-01-01T00:00:00.000Z', startedAt: null, endedAt: null,
+      tags: 'backend', messages: [],
+    })
+
+    const page = db.searchSessions('UI 記憶')
+    const ids = page.results.map(r => r.sessionId).sort()
+    expect(ids).toEqual(['fb-both'])
+  })
+
+  it('searchSessions LIKE fallback escapes wildcards in tokens', () => {
+    db.indexSession({
+      sessionId: 'fb-pct', projectId: 'proj-fb', projectDisplayName: '/test/fb',
+      title: 'UI 100% complete', messageCount: 0, filePath: '/tmp/pct.jsonl', fileSize: 0,
+      fileMtime: '2024-01-01T00:00:00.000Z', startedAt: null, endedAt: null,
+      messages: [],
+    })
+    db.indexSession({
+      sessionId: 'fb-clean', projectId: 'proj-fb', projectDisplayName: '/test/fb',
+      title: 'UI standard', messageCount: 0, filePath: '/tmp/clean.jsonl', fileSize: 0,
+      fileMtime: '2024-01-01T00:00:00.000Z', startedAt: null, endedAt: null,
+      messages: [],
+    })
+
+    const page = db.searchSessions('UI %')
+    const ids = page.results.map(r => r.sessionId)
+    expect(ids).toEqual(['fb-pct'])
+  })
+
   it('re-index updates sessions_fts', () => {
     db.indexSession({
       sessionId: 'sfts-upd', projectId: 'proj-upd', projectDisplayName: '/upd',

--- a/tests/memories.test.ts
+++ b/tests/memories.test.ts
@@ -161,6 +161,20 @@ describe('queryMemories LIKE fallback (short tokens)', () => {
     expect(results.length).toBe(1)
   })
 
+  it('caps token count to bound SQL prepare cost (DoS guard)', () => {
+    db.saveMemory(mem({ content: 'UI memory only', confidence: 0.9 }))
+    // Generate a giant query: 1000 unique short tokens. Without the cap this
+    // would build a 1000-clause SQL string (~hundreds of KB of SQL text + 1000
+    // bind params) on the synchronous event loop.
+    const giant = Array.from({ length: 1000 }, (_, i) => `t${i}`).join(' ')
+    const before = Date.now()
+    expect(() => db.queryMemories(giant, 10)).not.toThrow()
+    const elapsed = Date.now() - before
+    // Loose ceiling — capped query stays well under 100ms. Without the cap
+    // this regularly exceeds 500ms or hits SQLITE_RANGE.
+    expect(elapsed).toBeLessThan(500)
+  })
+
   it('LIKE wildcards in tokens are escaped (security)', () => {
     db.saveMemory(mem({ content: 'UI percent% sign', confidence: 0.9 }))
     db.saveMemory(mem({ content: 'UI no special', confidence: 0.8 }))

--- a/tests/memories.test.ts
+++ b/tests/memories.test.ts
@@ -110,6 +110,68 @@ describe('queryMemories', () => {
   })
 })
 
+describe('queryMemories LIKE fallback (short tokens)', () => {
+  // Trigram tokenizer cannot index tokens shorter than 3 chars. The fallback
+  // path runs LIKE on raw memory content. Single-token queries keep the simple
+  // substring behavior; multi-token queries (e.g. mixed Latin acronyms + CJK
+  // like `UI 記憶`, `DB 查詢`) AND each token, so a doc only matches when every
+  // token appears somewhere in content.
+
+  it('single short CJK token still hits via single-LIKE', () => {
+    db.saveMemory(mem({ content: '記憶系統設計', confidence: 0.8 }))
+    db.saveMemory(mem({ content: '無關內容', confidence: 0.8 }))
+    const results = db.queryMemories('記憶', 10)
+    expect(results.map(r => r.content)).toEqual(['記憶系統設計'])
+  })
+
+  it('single short Latin acronym still hits via single-LIKE', () => {
+    db.saveMemory(mem({ content: 'UI element refactor', confidence: 0.8 }))
+    db.saveMemory(mem({ content: 'unrelated', confidence: 0.8 }))
+    const results = db.queryMemories('UI', 10)
+    expect(results.map(r => r.content)).toEqual(['UI element refactor'])
+  })
+
+  it('mixed Latin + CJK uses AND across tokens (Case 5)', () => {
+    db.saveMemory(mem({ content: 'UI 元件設計優化記憶', confidence: 0.9 }))
+    db.saveMemory(mem({ content: '後台 API 跟前台 UI 的記憶共用', confidence: 0.85 }))
+    db.saveMemory(mem({ content: '純 UI 改動，沒動到資料層', confidence: 0.8 }))
+    db.saveMemory(mem({ content: '記憶系統的單元測試覆蓋率', confidence: 0.8 }))
+
+    const results = db.queryMemories('UI 記憶', 10)
+    const contents = results.map(r => r.content).sort()
+    expect(contents).toEqual([
+      'UI 元件設計優化記憶',
+      '後台 API 跟前台 UI 的記憶共用',
+    ].sort())
+  })
+
+  it('token order in query does not matter (AND is commutative)', () => {
+    db.saveMemory(mem({ content: 'UI 元件設計優化記憶', confidence: 0.9 }))
+    db.saveMemory(mem({ content: '純 UI 改動', confidence: 0.8 }))
+
+    const a = db.queryMemories('UI 記憶', 10)
+    const b = db.queryMemories('記憶 UI', 10)
+    expect(a.map(r => r.content)).toEqual(b.map(r => r.content))
+    expect(a.length).toBe(1)
+  })
+
+  it('extra whitespace between tokens is normalized', () => {
+    db.saveMemory(mem({ content: 'UI 元件設計記憶', confidence: 0.9 }))
+    const results = db.queryMemories('UI    記憶', 10)
+    expect(results.length).toBe(1)
+  })
+
+  it('LIKE wildcards in tokens are escaped (security)', () => {
+    db.saveMemory(mem({ content: 'UI percent% sign', confidence: 0.9 }))
+    db.saveMemory(mem({ content: 'UI no special', confidence: 0.8 }))
+
+    const results = db.queryMemories('UI %', 10)
+    // The literal `%` token must match only the doc that actually contains `%`,
+    // not match every doc as it would if `%` were treated as a wildcard.
+    expect(results.map(r => r.content)).toEqual(['UI percent% sign'])
+  })
+})
+
 describe('getMemoryCount', () => {
   it('returns 0 on empty', () => {
     expect(db.getMemoryCount()).toBe(0)


### PR DESCRIPTION
## Summary

Fixes Case 5 of issue #13: mixed Latin + CJK queries (e.g. `UI 記憶`, `DB 查詢`) silently lose hits because the short-token LIKE fallback wraps the entire raw query in `%...%`, collapsing AND semantics into substring match. Also caps fallback token count at 20 to prevent SQL prepare-time DoS.

## What changed

**`src/core/database.ts`** — two fallback methods rewritten:

- `queryMemoriesFallback` — was `WHERE content LIKE '%<rawQuery>%'`; now splits whitespace and ANDs each token's LIKE clause. Single-token short queries (bare `記憶`, `UI`) keep the existing single-LIKE behavior.
- `searchSessionsFallback` — same per-token AND, with each token applied independently to the 5 FTS columns (title / tags / files_touched / summary_text / intent_text) via OR. So a session matches if every token appears in *some* column — they don't all need to live in the same column.

**Security cap** — `MAX_FALLBACK_TOKENS = 20`. Without this, a caller passing 10000 tokens stalls the synchronous `prepare()` pass or hits `SQLITE_MAX_VARIABLE_NUMBER` (each token contributes 1 bind param in memories fallback, 5 in sessions fallback). 20 covers any realistic search query. Flagged as Medium / OWASP A10 / AI-vuln #5 by the security review pass.

## Why now

Reproduced all 5 deferred CJK edge cases from #13. Case 5 is the highest-impact:

```
docs:
  "UI 元件設計優化記憶"          ← has UI AND 記憶 (separated)
  "後台 API 跟前台 UI 的記憶共用" ← has UI AND 記憶 (separated)
  "純 UI 改動，沒動到資料層"     ← has UI but not 記憶
  "記憶系統的單元測試覆蓋率"     ← has 記憶 but not UI

before: queryMemories("UI 記憶") → 0 hits (false negative)
after:  queryMemories("UI 記憶") → 2 hits (semantic AND)
```

Mixed Latin + CJK queries (`DB 查詢`, `API 路由`, `UI 設計`, `CI 流程`) all hit this pattern — the most common real-world query shape was silently broken.

Cases 1 (full-width punctuation) / 2 (NFC↔NFD) / 3 (snippet boundary) / 4 (halfwidth ↔ fullwidth katakana) remain deferred until the storage governance work converges. See verification details in the issue thread.

## Test plan

- [x] 9 new tests covering: single short CJK / single short Latin / mixed Case 5 / token order independence / whitespace normalize / wildcard escape / DoS token cap / sessions Case 5 / sessions wildcard escape
- [x] `pnpm vitest run` — 472 / 472 passing (baseline 463; +9)
- [x] `pnpm build` — tsc clean
- [x] `pnpm eslint .` — clean
- [x] Backward compat verified: bare `記憶` and `UI` single-token queries reduce to identical single-LIKE behavior

## Quality pipeline

| Stage | Result |
|-------|--------|
| Codex Review | Skipped (Claude Code wrapper SIGKILL regression — output 0 bytes across 3 attempts; same-source caveat applies) |
| Simplify | No changes — three-lens review (Reuse / Quality / Efficiency) all pass |
| Security Lint | 1 Medium fixed: token count cap (commit `c02aa03`) |
| Final Verify | Build / Lint / Test all green |

Refs #13 (Case 5 only — Cases 1/2/3/4 still open).