### PR TITLE
fix(harvester): skip save-t process reports + scorer length gate

### DIFF
--- a/src/core/outcome-extractor.ts
+++ b/src/core/outcome-extractor.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { ParsedLine } from './types.js'
-import { scoreKnowledgeBearing, KNOWLEDGE_THRESHOLD } from './outcome-scorer.js'
+import { scoreKnowledgeBearing, KNOWLEDGE_THRESHOLD, isProcessReport } from './outcome-scorer.js'
 
 // 從 session 挑「last substantial assistant text」作為記憶候選,餵 outcome-scorer.ts 評分。
 // 與 summarizer.ts inferOutcome 區別:inferOutcome 推 OutcomeStatus(committed/tested/...),
@@ -29,6 +29,7 @@ function pickLastSubstantialAssistant(messages: ParsedLine[]): string | null {
     if (msg.role !== 'assistant') continue
     const text = msg.contentText?.trim()
     if (!text) continue
+    if (isProcessReport(text)) continue
     if (isSubstantial(text)) return text
   }
   return null

--- a/src/core/outcome-scorer.ts
+++ b/src/core/outcome-scorer.ts
@@ -19,6 +19,13 @@ const NOISE_RES: ReadonlyArray<RegExp> = [
   /^\s*(?:對|不對|是的|沒錯|好的|yes|no|yep|nope)\s*[.!。!]*\s*$/i,
 ]
 
+// dogfood corpus 實證(2026-05-06): 39 筆 v=2 committed/tested sessions 全部 sub-threshold,
+// 因為 last substantial assistant 抓到 save-t 收尾報告(process meta)而非真實 outcome。
+// Anchor 在開頭(^),長文本 mid-text 提及 save-t 不誤殺。
+const PROCESS_REPORT_RES: ReadonlyArray<RegExp> = [
+  /^[#\s💾🟢✅_*-]*save[\s-]?t\s+(?:完成|流程|done|finished|complete|完整)/iu,
+]
+
 interface SignalCategory {
   readonly name: string
   readonly patterns: ReadonlyArray<RegExp>
@@ -85,6 +92,7 @@ export interface ScoreResult {
 export function scoreKnowledgeBearing(text: string): ScoreResult {
   const trimmed = text.trim()
   if (isAssistantNoise(trimmed)) return { score: 0, reasons: ['noise'] }
+  if (isProcessReport(trimmed)) return { score: 0, reasons: ['process-report'] }
 
   const reasons: string[] = []
   let score = 0
@@ -100,4 +108,8 @@ export function scoreKnowledgeBearing(text: string): ScoreResult {
 function isAssistantNoise(text: string): boolean {
   if (text.length > NOISE_MAX_LEN) return false
   return NOISE_RES.some(p => p.test(text))
+}
+
+export function isProcessReport(text: string): boolean {
+  return PROCESS_REPORT_RES.some(p => p.test(text))
 }

--- a/src/core/outcome-scorer.ts
+++ b/src/core/outcome-scorer.ts
@@ -13,6 +13,9 @@
 // 避免被下面的 weak-signal 累計湊到 threshold。Pattern 採 anchored-only 設計,長文本不誤殺。
 
 const NOISE_MAX_LEN = 50
+// Process-report headers are short (save-t reports are <2KB in practice).
+// Length gate prevents regex linear-scan on megabyte-scale assistant text.
+const PROCESS_REPORT_MAX_LEN = 5000
 
 const NOISE_RES: ReadonlyArray<RegExp> = [
   /^\s*(?:done|完成|處理好了|實作好了|搞定|fixed|implemented|ok|okay)\s*[.!。!]*\s*$/i,
@@ -111,5 +114,6 @@ function isAssistantNoise(text: string): boolean {
 }
 
 export function isProcessReport(text: string): boolean {
+  if (text.length > PROCESS_REPORT_MAX_LEN) return false
   return PROCESS_REPORT_RES.some(p => p.test(text))
 }

--- a/src/core/outcome-scorer.ts
+++ b/src/core/outcome-scorer.ts
@@ -23,7 +23,7 @@ const NOISE_RES: ReadonlyArray<RegExp> = [
 // 因為 last substantial assistant 抓到 save-t 收尾報告(process meta)而非真實 outcome。
 // Anchor 在開頭(^),長文本 mid-text 提及 save-t 不誤殺。
 const PROCESS_REPORT_RES: ReadonlyArray<RegExp> = [
-  /^[#\s💾🟢✅_*-]*save[\s-]?t\s+(?:完成|流程|done|finished|complete|完整)/iu,
+  /^[#\s💾🟢✅_*-]*\/?save[\s-]?t(?:\s*[:：]\s*|\s+)(?:完成|流程完整|完整|done|finished|completed?)/iu,
 ]
 
 interface SignalCategory {

--- a/tests/outcome-extractor.test.ts
+++ b/tests/outcome-extractor.test.ts
@@ -101,4 +101,28 @@ describe('extractOutcome — candidateText', () => {
     const msgs = [makeMsg({ role: 'assistant', contentText: text })]
     expect(extractOutcome(msgs).candidateText).toBeNull()
   })
+
+  it('skips trailing save-t process report and falls back to real outcome', () => {
+    // dogfood pattern: session 末尾常常是 save-t 收尾報告（非 outcome）,
+    // 真實 implementation outcome 在 save-t 之前。extractor 應 skip save-t 往前找。
+    const realOutcome =
+      'Root cause: WAL never truncates, fixed at src/core/database.ts:1552. ' +
+      'Verified: 495/495 tests pass after the change. We decided to add TRUNCATE at end of indexer.'
+    const saveTReport =
+      '## save-t 完成 ✓\n\n寫入摘要：\n| 檔案 | 動作 |\n|---|---|\n| RESUME.md | 更新 |'
+    const msgs = [
+      makeMsg({ role: 'assistant', contentText: realOutcome }),
+      makeMsg({ role: 'user', contentText: '/save-t' }),
+      makeMsg({ role: 'assistant', contentText: saveTReport }),
+    ]
+    expect(extractOutcome(msgs).candidateText).toBe(realOutcome)
+  })
+
+  it('returns null when only save-t reports exist', () => {
+    const msgs = [
+      makeMsg({ role: 'assistant', contentText: 'Save-T 完成。\n\n## 輸出摘要\n更新了 3 個檔案。' }),
+      makeMsg({ role: 'assistant', contentText: '## save-t 完成 ✓\n\n寫入動作完成' }),
+    ]
+    expect(extractOutcome(msgs).candidateText).toBeNull()
+  })
 })

--- a/tests/outcome-scorer.test.ts
+++ b/tests/outcome-scorer.test.ts
@@ -71,6 +71,13 @@ describe('scoreKnowledgeBearing — process-report short-circuit', () => {
     expect(scoreKnowledgeBearing('we save the result to disk').reasons).not.toContain('process-report')
     expect(scoreKnowledgeBearing('auto-save token expired').reasons).not.toContain('process-report')
   })
+
+  it('skips process-report check on oversized input (security: prevent regex scan on megabyte text)', () => {
+    // Length gate: inputs >5KB cannot be a save-t report (always short headers)
+    const oversized = '## save-t 完成\n\n' + 'x'.repeat(6000)
+    const result = scoreKnowledgeBearing(oversized)
+    expect(result.reasons).not.toContain('process-report')
+  })
 })
 
 describe('scoreKnowledgeBearing — decision-language', () => {

--- a/tests/outcome-scorer.test.ts
+++ b/tests/outcome-scorer.test.ts
@@ -26,6 +26,36 @@ describe('scoreKnowledgeBearing — noise short-circuit', () => {
   })
 })
 
+describe('scoreKnowledgeBearing — process-report short-circuit', () => {
+  // dogfood corpus 實證：39 筆 v=2 committed/tested sessions 全部 sub-threshold,
+  // last substantial assistant 抓到 save-t 收尾報告 (process-report) 而非真實 outcome。
+  // 短路設計：開頭符合 save-t 樣式 → score 0，避免下游 scorer pattern 偶然湊分。
+  it('flags save-t completion reports (CJK heading)', () => {
+    expect(scoreKnowledgeBearing('## save-t 完成 ✓\n\n寫入摘要表格...').reasons).toEqual(['process-report'])
+    expect(scoreKnowledgeBearing('Save-T 完成。\n\n## 輸出摘要').reasons).toEqual(['process-report'])
+    expect(scoreKnowledgeBearing('Save-t 流程完整。').reasons).toEqual(['process-report'])
+  })
+
+  it('flags save-t completion reports with emoji prefix', () => {
+    expect(scoreKnowledgeBearing('# 💾 Save-T 完成\n\n## 已更新檔案').reasons).toEqual(['process-report'])
+  })
+
+  it('flags save-t completion reports (EN)', () => {
+    expect(scoreKnowledgeBearing('## Save-T done\n\nupdated files...').reasons).toEqual(['process-report'])
+    expect(scoreKnowledgeBearing('Save-t finished. Updated 3 files.').reasons).toEqual(['process-report'])
+  })
+
+  it('does NOT flag mid-text save-t mentions', () => {
+    const text = 'After we ran save-t, the tests passed. Root cause: src/auth.ts:42.'
+    expect(scoreKnowledgeBearing(text).reasons).not.toContain('process-report')
+  })
+
+  it('does NOT flag unrelated "save" verbs', () => {
+    expect(scoreKnowledgeBearing('we save the result to disk').reasons).not.toContain('process-report')
+    expect(scoreKnowledgeBearing('auto-save token expired').reasons).not.toContain('process-report')
+  })
+})
+
 describe('scoreKnowledgeBearing — decision-language', () => {
   it('hits CJK decision verbs', () => {
     expect(scoreKnowledgeBearing('我們決定改用 SQLite 而非 LMDB').reasons).toContain('decision-language')

--- a/tests/outcome-scorer.test.ts
+++ b/tests/outcome-scorer.test.ts
@@ -45,6 +45,23 @@ describe('scoreKnowledgeBearing — process-report short-circuit', () => {
     expect(scoreKnowledgeBearing('Save-t finished. Updated 3 files.').reasons).toEqual(['process-report'])
   })
 
+  it('flags slash-command save-t headings (Codex M1)', () => {
+    // /save-t is the documented skill name — assistant may echo it verbatim
+    expect(scoreKnowledgeBearing('## /save-t 完成 ✓\n\n寫入摘要').reasons).toEqual(['process-report'])
+    expect(scoreKnowledgeBearing('/save-t finished. 3 files updated.').reasons).toEqual(['process-report'])
+  })
+
+  it('flags colon-separated save-t reports (Codex M1)', () => {
+    expect(scoreKnowledgeBearing('Save-T: done\n\nupdated 3 files').reasons).toEqual(['process-report'])
+    expect(scoreKnowledgeBearing('save-t：完成\n\n摘要表格').reasons).toEqual(['process-report'])
+  })
+
+  it('does NOT misfire on save-t with non-completion follow-up (Codex L1)', () => {
+    // Bare 流程 was too broad — must be 流程完整, not 流程不完整 / 流程 root cause
+    expect(scoreKnowledgeBearing('Save-t 流程不完整,還缺 RESUME.md').reasons).not.toContain('process-report')
+    expect(scoreKnowledgeBearing('Save-t 流程 root cause: WAL truncate').reasons).not.toContain('process-report')
+  })
+
   it('does NOT flag mid-text save-t mentions', () => {
     const text = 'After we ran save-t, the tests passed. Root cause: src/auth.ts:42.'
     expect(scoreKnowledgeBearing(text).reasons).not.toContain('process-report')


### PR DESCRIPTION
## Summary

- **Root cause**: dogfood corpus audit (2026-05-06) found 39 v=2 committed/tested sessions all sub-threshold because `extractOutcome.pickLastSubstantialAssistant` captured save-t completion reports (process meta) instead of real implementation outcomes
- **Fix**: extractor now skips process-report candidates and walks back to earlier substantial assistant text; scorer short-circuits process-report to score 0 (defense in depth)
- **Note**: this is a **prerequisite fix, not sufficient** — audit shows real outcomes now reach scorer but stay sub-threshold due to category coverage gaps (CJK commit-confirmation, `## 修復總結` tables). Pattern coverage extension tracked separately

## Commits

| SHA | Stage | Notes |
|-----|-------|-------|
| `e96f0eb` | A+C mechanism | extractor skip + scorer short-circuit + PROCESS_REPORT_RES + 11 tests |
| `db68cdb` | Codex review | M1 (slash/colon regex gap) + L1 (流程 alternation too broad) |
| `675c660` | Security lint | M01 (ReDoS length gate, PROCESS_REPORT_MAX_LEN=5000) |

## Quality pipeline (gogo)

- ✅ Codex Review: 1 Medium + 1 Low → fixed
- ⏭️ Simplify: 4 candidates considered, all ruled out (no genuine simplification)
- ✅ Security: 1 Medium fixed; 3 Low declined per gogo override
- ✅ Final Verify: build / typecheck / lint / 535 tests all green
- ⏭️ Security Δ: not triggered (no autofix in final verify)

## Test plan

- [x] `pnpm vitest run` — 535/535 green (524 → +11)
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm eslint .` — clean
- [x] `pnpm build` — clean
- [x] Audit script (`.claude/audit-scorer-39.ts`, gitignored) — confirmed save-t no longer captured; real outcomes now reach scorer

## Follow-ups (not in this PR)

- Open issue: CJK implementation-summary scorer pattern coverage (counterpart to #23 EN corpus gap)
- 0.2.7 release: bundle this fix with 5/7 cleanup of legacy [intent]% noise (16 query-type rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)