### PR TITLE
P1 (#21): split low-trust session_journal from high-trust memories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,99 @@ more like an iteration counter than a strict SemVer major).
 
 ---
 
+## [0.3.0] — 2026-05-06
+
+### ⚠️ Breaking — harvest write path
+
+Hook auto-harvester (`POST /session/end`) now writes to a new
+`session_journal` table instead of `memories`. Manual `recall_save` is
+unchanged — it still writes directly to `memories`. This is the
+architectural fix for issue #21 (and the underlying root cause of
+issue #25's 0/39 hit rate): the rule scorer was on the persistence
+gate, not on a trust grade. Adding more regex patterns would have only
+delayed the next failure mode. Splitting low-trust harvest from
+high-trust memories lets the harvester record candidates broadly while
+recall results stay clean.
+
+`recall_query` / `recall_context` / `recall_query` results are not
+affected by journal entries — by design they only read `memories`.
+
+**Response field rename**: `POST /session/end` returns `journalSaved`
+(was `memoriesSaved`). Hooks ignore the response body, so installed
+hooks continue to work without reinstall.
+
+### Added
+
+- **Schema v22**: `session_journal` table with `(session_id, message_id,
+  content, content_hash, score, reasons_json, status, expires_at,
+  promoted_memory_id, project_id, created_at)`. `idx_journal_status`
+  and `idx_journal_hash UNIQUE` for sweep + idempotency.
+- **`ccmem promote <id>`** — manual promotion to memories. Atomic:
+  saveMemory → saveMemoryTopics → rebuildKnowledgeMap →
+  promoteJournalEntry. Optional `--type` (default `discovery`) and
+  `--confidence` (default `0.7`) flags. Returns 409 if already
+  promoted, 404 if not found.
+- **`ccmem reject <id>`** — soft-delete with 7-day TTL via `expires_at`.
+  Decay sweep cleans up after expiry.
+- **`/health` endpoint** gains `journalPendingCount`. Surfacing the
+  pending queue is how users discover candidates worth promoting —
+  manual-only on purpose; auto-promote would re-introduce the failure
+  mode we just removed.
+- **Decay sweep** in the existing `MaintenanceCoordinator` tick:
+  rejected past `expires_at` and pending older than 30 days are
+  deleted. Promoted entries kept as audit trail. Memories table never
+  touched (manual saves exempt by table boundary).
+
+### Changed
+
+- `summarizer.ts` removed the `score >= KNOWLEDGE_THRESHOLD` (≥ 2)
+  persistence gate. Hard floor preserved: `noise` / `process-report`
+  reasons still short-circuit (these are not knowledge regardless of
+  where they land).
+- `buildMemoryFromSession` renamed to `buildJournalCandidate`, returns
+  `JournalEntryInput` with re-scored `score` + `reasonsJson` metadata.
+  Score is recomputed at journal-write time (cheap regex on <2KB text)
+  so we don't need a v23 migration for `harvest_score` columns.
+
+### Migration
+
+- v22 migration runs automatically on daemon startup. Pre-check throws
+  if `memories` table is missing (would dangle FK), recommending
+  restore from pre-v22 backup.
+- **Backup recommended before upgrading**:
+  `cp ~/.ccrecall/ccrecall.db ~/.ccrecall/ccrecall.db.pre-v22.bak`
+- Existing memories rows stay queryable as before. The 17 historical
+  `type='query'` rows from v0.2.x harvest are not migrated to journal —
+  they're frozen in place; new harvest writes go to journal from now.
+
+### Tests
+
+- +22 tests across 5 commits (schema target / journal DAO / trust
+  boundary / promote+reject endpoints / sweep TTL / health field)
+- 535 → 557 tests passing.
+
+### First-run observation period
+
+Plan-critic acceptance criteria:
+
+| Day | Indicator | Threshold | Failure reading |
+|-----|-----------|-----------|-----------------|
+| 14  | journal write count | ≥ 50 | gate-removal didn't unblock — issue is upstream of `pickLastSubstantialAssistant` |
+| 30  | manual promote count | ≥ 3  | surfacing is insufficient — escalate to issue #21 P2 (promotion UX) |
+
+Tracking: [issue #21](https://github.com/tznthou/ccRecall/issues/21).
+
+### Upgrade checklist
+
+- `pnpm install -g @tznthou/ccrecall@0.3.0` (or your usual install path).
+- Optional: backup DB before restart (see Migration section).
+- `launchctl kickstart -k gui/$UID/com.tznthou.ccrecall` to restart the
+  daemon. v22 migration runs on first connection.
+- `curl http://127.0.0.1:7749/health` — verify `version: "0.3.0"` and
+  the new `journalPendingCount` field.
+
+---
+
 ## [0.2.7] — 2026-05-06
 
 ### Fixed

--- a/CHANGELOG_ZH.md
+++ b/CHANGELOG_ZH.md
@@ -8,6 +8,89 @@ ccRecall 的重要版本變更記錄在這裡。
 
 ---
 
+## [0.3.0] — 2026-05-06
+
+### ⚠️ Breaking — harvest 寫入路徑
+
+Hook auto-harvester（`POST /session/end`）改寫到新建的 `session_journal`
+表,不再寫 `memories`。Manual `recall_save` 不受影響——仍直寫 `memories`。
+這是 issue #21（也是 issue #25 0/39 命中率底層根因）的架構修正:rule scorer
+原本架在 persistence gate,實際位置應該是 trust grade。再補 regex 只會延後
+下次撞牆。把 low-trust harvest 跟 high-trust memories 分開後,harvester 可以
+廣捕候選,但 recall 結果保持乾淨。
+
+`recall_query` / `recall_context` 結果不受 journal 影響——by design 它們只
+讀 `memories`。
+
+**Response 欄位改名**: `POST /session/end` 回 `journalSaved`(原 `memoriesSaved`)。
+Hook 端不解析 response body,既裝 hook 不需重裝。
+
+### 新增
+
+- **Schema v22**: `session_journal` 表含 `(session_id, message_id, content,
+  content_hash, score, reasons_json, status, expires_at, promoted_memory_id,
+  project_id, created_at)`。`idx_journal_status` 與 `idx_journal_hash UNIQUE`
+  支撐 sweep + idempotency。
+- **`ccmem promote <id>`** — manual 升級到 memories。Atomic: saveMemory
+  → saveMemoryTopics → rebuildKnowledgeMap → promoteJournalEntry。
+  optional `--type`(預設 `discovery`)、`--confidence`(預設 `0.7`)。已 promoted
+  回 409;不存在回 404。
+- **`ccmem reject <id>`** — soft-delete,7 天 TTL via `expires_at`。decay sweep
+  到期後清理。
+- **`/health` endpoint** 加 `journalPendingCount`。surfacing pending queue 是
+  user 發現可 promote 候選的方式——manual-only by design;auto-promote 會
+  重蹈 threshold gate 覆轍。
+- **Decay sweep** 在既有 `MaintenanceCoordinator` tick 內: rejected 過
+  `expires_at` + pending 超過 30 天 → DELETE。promoted 留作 audit trail。
+  memories 表不被碰(manual 寫入由 table 邊界自動 exempt)。
+
+### 變更
+
+- `summarizer.ts` 移除 `score >= KNOWLEDGE_THRESHOLD`(≥ 2)persistence gate。
+  hard floor 保留: `noise` / `process-report` 仍 short-circuit(這些不論落
+  到哪裡都不是 knowledge)。
+- `buildMemoryFromSession` rename 為 `buildJournalCandidate`,return
+  `JournalEntryInput` 含重新 score 後的 `score` + `reasonsJson` metadata。
+  Score 在 journal 寫入時重算(<2KB 文字 regex,成本低),不需 v23 migration
+  加 `harvest_score` 欄位。
+
+### Migration
+
+- v22 migration 在 daemon startup 自動跑。pre-check: `memories` 表必須存在
+  (否則 dangle FK,throw 提示從 pre-v22 backup restore)。
+- **升級前建議先 backup**:
+  `cp ~/.ccrecall/ccrecall.db ~/.ccrecall/ccrecall.db.pre-v22.bak`
+- 既有 memories rows 不變。v0.2.x 17 筆 `type='query'` 記憶不被搬到 journal
+  ——凍結在原位,新 harvest 從現在開始寫 journal。
+
+### 測試
+
+- 跨 5 個 commit 加 +22 tests(schema target / journal DAO / trust boundary
+  / promote+reject endpoints / sweep TTL / health 欄位)
+- 535 → 557 tests passing。
+
+### 首發觀察期
+
+Plan-critic acceptance criteria:
+
+| 天數 | 指標 | 通過閾值 | 不通過解讀 |
+|---|---|---|---|
+| 14 | journal 寫入總筆數 | ≥ 50 | 移除 gate 沒解到問題——上游 `pickLastSubstantialAssistant` 才是真根因 |
+| 30 | manual promote 累計 | ≥ 3 | surfacing 不夠——啟動 issue #21 P2 規劃 |
+
+追蹤: [issue #21](https://github.com/tznthou/ccRecall/issues/21)。
+
+### 升級清單
+
+- `pnpm install -g @tznthou/ccrecall@0.3.0`(或您慣用的安裝路徑)。
+- 可選: 重啟前先 backup DB(見 Migration 段)。
+- `launchctl kickstart -k gui/$UID/com.tznthou.ccrecall` 重啟 daemon,
+  v22 migration 在第一次連線時跑。
+- `curl http://127.0.0.1:7749/health` 驗 `version: "0.3.0"` 及新增的
+  `journalPendingCount` 欄位。
+
+---
+
 ## [0.2.7] — 2026-05-06
 
 ### 修正

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ A local memory service for Claude Code — indexes your conversation history, re
 
 ---
 
-> ⚠️ **v0.2.6 — English coverage caveat**
+> 📐 **v0.3.0 — Trust split (breaking change for harvest write path)**
 >
-> The harvester's knowledge-bearing scorer (introduced in v0.2.6) was corpus-validated against Mandarin Chinese sessions only. Each of the 5 signal categories ships with 1–3 anchor patterns per language as plan-time scaffolding. **English-language sessions may see a higher skip rate than expected** — the harvester will write fewer new memories until pattern coverage expands.
+> The SessionEnd hook now writes to a low-trust `session_journal` table instead of `memories`. Journal entries are scored, surfaced via `/health` (`journalPendingCount`), and **do not appear in `recall_query` / `recall_context` results** until you run `ccmem promote <id>`. Manual `recall_save` is unchanged — it still writes directly to high-trust `memories`.
 >
-> If you observe English outcome sessions failing to harvest, please contribute a redacted excerpt at [issue #23](https://github.com/tznthou/ccRecall/issues/23) — that's the corpus we need to expand coverage deliberately rather than by guesswork.
+> The rule scorer is no longer on the persistence gate; it informs trust grade and promotion priority instead. Background reasoning at [issue #21](https://github.com/tznthou/ccRecall/issues/21).
 >
-> Memories accumulated pre-v0.2.6 are preserved; a separate cleanup release will purge legacy noise after a 7-day observation window.
+> Pre-0.3.0 memories stay queryable as-is. The v22 schema migration runs automatically on first daemon startup; existing rows are not touched. New harvest goes to journal from now on.
 
 ---
 
@@ -43,6 +43,7 @@ ccRecall is the "memory" counterpart to [ccRewind](https://github.com/tznthou/cc
 | **Incremental indexing** | Only re-indexes sessions that changed (mtime diffing), handles resumed sessions via UUID dedup |
 | **Metacognition** | `knowledge_map` aggregates topic mentions from sessions + memories. Depth derived from mention count (shallow / medium / deep). Exposed via `/metacognition/check` and MCP `recall_context` |
 | **Forgetting curve** | Memories compress over time: raw → summary → one-liner → deleted. Confidence decays on unused memories. Background maintenance tick runs every 5 min |
+| **Trust two-tier** (v0.3.0) | Hooks write to a low-trust `session_journal` (reviewable, never recalled directly); manual `recall_save` writes high-trust `memories`. Promote candidates with `ccmem promote <id>`; rejected entries auto-clear after 7 days |
 | **Watch mode** | chokidar-based JSONL watcher picks up new sessions within 2 s; periodic 10 min full-resync covers missed filesystem events |
 | **Rescue reindex** | `/session/end` retries a reindex on cache miss — no fresh-session race between the hook and the daemon |
 | **Auto-start (macOS)** | `ccmem install-daemon` registers a LaunchAgent so the service stays up across reboots |
@@ -88,7 +89,7 @@ flowchart TB
 | FTS5 | Full-text search | Built into SQLite, trigram tokenizer with LIKE fallback for short CJK / mixed-script queries |
 | Native `http` | HTTP server | No Express — minimal surface, localhost only |
 | chokidar | Filesystem watcher | Cross-platform JSONL change detection with 2 s debounce + single-flight |
-| vitest | Testing | 475 tests across 32 files, integration-style |
+| vitest | Testing | 562 tests across 37 files, integration-style |
 | `@modelcontextprotocol/sdk` | MCP server | stdio transport, shared SQLite via WAL |
 
 ---
@@ -132,10 +133,13 @@ curl "http://127.0.0.1:7749/memory/query?q=authentication&limit=5"
 
 | Endpoint | Method | Description | Status |
 |----------|--------|-------------|--------|
-| `/health` | GET | Service health + DB stats + integrity check status | Live |
-| `/memory/query?q=...&limit=...&project=...` | GET | FTS5 search across memories with optional project filter | Live |
+| `/health` | GET | Service health + DB stats + integrity check status + `journalPendingCount` (since v0.3.0) | Live |
+| `/memory/query?q=...&limit=...&project=...` | GET | FTS5 search across memories with optional project filter (journal entries excluded by design) | Live |
 | `/memory/save` | POST | Save a memory entry (origin-checked) | Live |
-| `/session/end` | POST | Harvest a finished session's summary into a memory (idempotent) | Live |
+| `/session/end` | POST | Harvest a finished session into `session_journal` (idempotent; was `memories` pre-0.3.0) | Live |
+| `/journal/pending` | GET | List journal entries awaiting promotion review | Live (v0.3.0) |
+| `/journal/promote` | POST | Atomically promote a journal entry into `memories` | Live (v0.3.0) |
+| `/journal/reject` | POST | Soft-delete a journal entry (cleared after 7-day TTL by decay sweep) | Live (v0.3.0) |
 | `/memory/context?session_id=...` | GET | Session context lookup | Stub |
 | `/metacognition/check?projectId=...[&topic=...]` | GET | Knowledge map: summary (top/recent/stale topics + counts) or topic detail (memories + related topics) | Live |
 | `/session/checkpoint` | POST | Mid-session snapshot into dedicated `session_checkpoints` table (not harvested as memory) | Live |
@@ -175,6 +179,40 @@ See [hooks/README.md](hooks/README.md) for SessionStart / SessionEnd hook instal
 
 ---
 
+## CLI Commands
+
+`@tznthou/ccrecall` ships two binaries:
+
+- **`ccmem`** — daemon launcher + admin commands
+- **`ccmem-mcp`** — MCP server (registered with Claude Code via `claude mcp add`)
+
+Daemon and hook lifecycle (macOS):
+
+| Command | Purpose |
+|---------|---------|
+| `ccmem` | Run the daemon in foreground |
+| `ccmem install-daemon` | Register a LaunchAgent (auto-start at login) |
+| `ccmem uninstall-daemon` | Stop and remove the LaunchAgent |
+| `ccmem install-hooks` | Merge SessionStart / SessionEnd entries into `~/.claude/settings.json` |
+| `ccmem uninstall-hooks` | Remove ccRecall's hook entries (other hooks untouched) |
+
+Journal review (since v0.3.0):
+
+| Command | Purpose |
+|---------|---------|
+| `ccmem promote <id>` | Promote a journal entry into `memories`. Optional `--type` (default `discovery`) and `--confidence` (default `0.7`) |
+| `ccmem reject <id>` | Soft-delete a journal entry; cleaned up after the 7-day TTL by the decay sweep |
+
+Surface pending candidates:
+
+```bash
+curl http://127.0.0.1:7749/journal/pending
+# or just check the count
+curl http://127.0.0.1:7749/health | jq .journalPendingCount
+```
+
+---
+
 ## ccRecall vs auto memory
 
 ccRecall lives alongside Claude Code's built-in auto memory (`~/.claude/projects/*/memory/`). They're complementary — use them for different things.
@@ -191,6 +229,8 @@ ccRecall lives alongside Claude Code's built-in auto memory (`~/.claude/projects
 **Default for querying:** MEMORY.md is already in context — check the index first. Fall back to `recall_query` / `recall_context` only when the user references past work and auto memory has no matching entry.
 
 ccRecall's value is the long tail that auto memory can't cover (nobody hand-curates 500 sessions of notes). If Claude defaults to both, auto memory wins because it's already loaded and curated. ccRecall earns its keep when the curated index misses.
+
+**Within ccRecall there's now a second trust split** (since v0.3.0). The SessionEnd hook writes to a low-trust `session_journal` table that `recall_query` does **not** read. Promote a candidate to high-trust `memories` with `ccmem promote <id>` to make it queryable. Manual `recall_save` skips the journal entirely — it writes straight to memories. The point is to let the harvester record broadly while keeping recall results clean.
 
 ---
 
@@ -274,7 +314,7 @@ ccRecall/
 │   │   ├── memory-service.ts     # Memory lifecycle (touch / delete / update)
 │   │   ├── compression.ts        # L0→L1→L2→delete state machine
 │   │   ├── lint.ts               # Orphan / stale memory detection
-│   │   ├── maintenance-coordinator.ts  # Background compression tick
+│   │   ├── maintenance-coordinator.ts  # Background compression tick + journal decay sweep
 │   │   ├── watcher.ts            # chokidar JSONL watcher (Phase 4e)
 │   │   └── log-safe.ts           # scrubErrorMessage — log-injection defence
 │   ├── api/
@@ -284,7 +324,8 @@ ccRecall/
 │   │   ├── server.ts             # MCP stdio server entry (shebang bin)
 │   │   └── tools.ts              # recall_query + recall_context + recall_save
 │   ├── cli/
-│   │   └── daemon.ts             # install-daemon / uninstall-daemon (macOS)
+│   │   ├── daemon.ts             # install-daemon / uninstall-daemon (macOS)
+│   │   └── journal.ts            # ccmem promote / reject (since v0.3.0)
 │   └── index.ts                  # HTTP entry point + subcommand dispatch
 ├── hooks/
 │   ├── session-start.mjs         # Inject memories on SessionStart (stdout)
@@ -294,10 +335,11 @@ ccRecall/
 │   ├── tutorial.md               # End-user walkthrough (install → MCP → usage)
 │   ├── architecture.md           # Daemon design rationale (contributor-oriented)
 │   └── launchd.md                # macOS LaunchAgent install/troubleshoot
-├── tests/                        # 475 tests across 32 files (parser, scanner,
+├── tests/                        # 562 tests across 37 files (parser, scanner,
 │   │                             # summarizer, database, indexer, e2e, MCP,
 │   │                             # memories, hooks, watcher, CLI, migrations,
-│   │                             # FTS5 CJK edge cases, integrity monitor, ...)
+│   │                             # FTS5 CJK edge cases, integrity monitor,
+│   │                             # session_journal DAO, promote+reject, sweep, ...)
 │   └── fixtures/                 # Sample JSONL + shared test helpers
 ├── .mcp.json.example             # MCP client config template
 └── NOTICE / SECURITY.md / CONTRIBUTING.md / CODE_OF_CONDUCT.md

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -11,13 +11,13 @@ Claude Code 的本地記憶服務——索引你的對話歷史，按需召回�
 
 ---
 
-> ⚠️ **v0.2.6 — 英文覆蓋率說明**
+> 📐 **v0.3.0 — Trust 二層拆分（harvest 寫入路徑 breaking change）**
 >
-> v0.2.6 引入的 outcome scorer 採用「5 類訊號 × 每語言 1–3 個 anchor pattern」的規則式評分,但 corpus 實測只跑過繁中 session（維護者自己 dogfood 的 dataset）。**英文 session 的 skip rate 可能高於預期**——直到 pattern 覆蓋擴充之前,harvester 會寫進來的新記憶較少。
+> SessionEnd hook 改寫到新建的 low-trust `session_journal` 表，不再寫 `memories`。Journal 條目會評分、透過 `/health` 的 `journalPendingCount` 露出，**`recall_query` / `recall_context` 不會直接召回 journal 條目**，需要先 `ccmem promote <id>` 升級。Manual `recall_save` 不變——仍直寫 high-trust `memories`。
 >
-> 如果觀察到英文 session 該抓的 outcome 沒被抓到,請到 [issue #23](https://github.com/tznthou/ccRecall/issues/23) 留 redacted 對話片段——這是我們擴充 corpus 唯一需要的資訊,讓 pattern 依證據成長而不是靠猜。
+> Rule scorer 不再卡在 persistence gate；改成提供 trust grade 與 promote 優先序。完整 rationale 見 [issue #21](https://github.com/tznthou/ccRecall/issues/21)。
 >
-> v0.2.6 之前累積的 memories 會保留;另一個 cleanup release 會在 7 天觀察期後清掉舊雜訊。
+> 0.3.0 之前的 memories 仍可正常查詢。v22 schema migration 在 daemon 第一次啟動時自動跑，既有 row 不會被動。新 harvest 從現在起寫 journal。
 
 ---
 
@@ -43,6 +43,7 @@ ccRecall 是 [ccRewind](https://github.com/tznthou/ccRewind)（對話回放 GUI�
 | **增量索引** | 只重新索引有變動的 session（mtime 比對），透過 UUID 去重處理接續 session |
 | **元認知** | `knowledge_map` 聚合 session + memory 的主題提及。由 mention count 衍生深度（shallow / medium / deep）。透過 `/metacognition/check` 與 MCP `recall_context` 暴露 |
 | **遺忘曲線** | 記憶隨時間壓縮：原始→摘要→一行結論→刪除。未使用的記憶信心衰減。背景維護 tick 每 5 分鐘跑一次 |
+| **Trust 二層**（v0.3.0） | Hook 寫入 low-trust `session_journal`（可審閱、不被 recall）；manual `recall_save` 寫 high-trust `memories`。用 `ccmem promote <id>` 升級候選；reject 後 7 天 TTL 自動清 |
 | **Watch mode** | 基於 chokidar 的 JSONL watcher 在 2 秒內偵測新 session；每 10 分鐘 full-resync 補救 FS 事件漏接 |
 | **Rescue reindex** | `/session/end` 遇到 cache miss 時會重 index 再試一次——hook 和 daemon 間不會有 fresh-session race |
 | **macOS 自動啟動** | `ccmem install-daemon` 安裝 LaunchAgent，重開機自動復原服務 |
@@ -88,7 +89,7 @@ flowchart TB
 | FTS5 | 全文搜尋 | SQLite 內建、trigram tokenizer，短 token / 中英混合查詢透過 LIKE fallback 補齊 |
 | 原生 `http` | HTTP 伺服器 | 不用 Express——最小表面積、僅 localhost |
 | chokidar | 檔案系統 watcher | 跨平台 JSONL 變動偵測，2 秒 debounce + single-flight |
-| vitest | 測試 | 475 個測試（32 檔案）、整合式風格 |
+| vitest | 測試 | 562 個測試（37 檔案）、整合式風格 |
 | `@modelcontextprotocol/sdk` | MCP server | stdio transport，透過 WAL 共用 SQLite |
 
 ---
@@ -132,10 +133,13 @@ curl "http://127.0.0.1:7749/memory/query?q=authentication&limit=5"
 
 | 端點 | 方法 | 說明 | 狀態 |
 |------|------|------|------|
-| `/health` | GET | 服務健康 + DB 統計 + integrity 檢查狀態 | 已上線 |
-| `/memory/query?q=...&limit=...&project=...` | GET | FTS5 跨 session 搜尋，可選 project 過濾 | 已上線 |
+| `/health` | GET | 服務健康 + DB 統計 + integrity 檢查狀態 + `journalPendingCount`（v0.3.0 新增） | 已上線 |
+| `/memory/query?q=...&limit=...&project=...` | GET | FTS5 跨 session 搜尋，可選 project 過濾（journal 條目 by design 不含） | 已上線 |
 | `/memory/save` | POST | 儲存記憶條目（Origin 驗證） | 已上線 |
-| `/session/end` | POST | 從結束的 session 萃取記憶（idempotent） | 已上線 |
+| `/session/end` | POST | 把結束的 session 寫入 `session_journal`（idempotent；0.3.0 前是寫 `memories`） | 已上線 |
+| `/journal/pending` | GET | 列出待 promote 審閱的 journal 條目 | 已上線（v0.3.0） |
+| `/journal/promote` | POST | atomic 把 journal 條目升級到 `memories` | 已上線（v0.3.0） |
+| `/journal/reject` | POST | soft-delete journal 條目（7 天 TTL，由 decay sweep 清理） | 已上線（v0.3.0） |
 | `/memory/context?session_id=...` | GET | Session context 查詢 | Stub |
 | `/metacognition/check?projectId=...[&topic=...]` | GET | 知識地圖：summary（top/recent/stale topics + counts）或 topic detail（memories + related topics） | 已上線 |
 | `/session/checkpoint` | POST | 會話中途快照寫入獨立 `session_checkpoints` 表（不會被 harvest 成 memory） | 已上線 |
@@ -173,6 +177,40 @@ SessionStart / SessionEnd hook 安裝見 [hooks/README.md](hooks/README.md)。
 
 ---
 
+## CLI 指令
+
+`@tznthou/ccrecall` 提供兩個 binary：
+
+- **`ccmem`** — daemon 啟動 + 管理指令
+- **`ccmem-mcp`** — MCP server（透過 `claude mcp add` 註冊到 Claude Code）
+
+Daemon 與 hook 生命週期（macOS）：
+
+| 指令 | 用途 |
+|------|------|
+| `ccmem` | 前景跑 daemon |
+| `ccmem install-daemon` | 註冊 LaunchAgent（開機自動啟動） |
+| `ccmem uninstall-daemon` | 停掉並移除 LaunchAgent |
+| `ccmem install-hooks` | 把 SessionStart / SessionEnd 條目合併進 `~/.claude/settings.json` |
+| `ccmem uninstall-hooks` | 移除 ccRecall 自己的 hook 條目（其他 hook 不動） |
+
+Journal 審閱（v0.3.0 新增）：
+
+| 指令 | 用途 |
+|------|------|
+| `ccmem promote <id>` | 把 journal 條目升級到 `memories`。可選 `--type`（預設 `discovery`）、`--confidence`（預設 `0.7`） |
+| `ccmem reject <id>` | soft-delete journal 條目；7 天 TTL 後由 decay sweep 清掉 |
+
+查待 promote 候選：
+
+```bash
+curl http://127.0.0.1:7749/journal/pending
+# 或只看計數
+curl http://127.0.0.1:7749/health | jq .journalPendingCount
+```
+
+---
+
 ## ccRecall 與 auto memory 的分工
 
 ccRecall 和 Claude Code 內建的 auto memory（`~/.claude/projects/*/memory/`）是互補關係，各司其職，不要混用。
@@ -189,6 +227,8 @@ ccRecall 和 Claude Code 內建的 auto memory（`~/.claude/projects/*/memory/`�
 **查詢預設：MEMORY.md 已經在 context 裡，先看 index 有沒有。** auto memory 沒答案，才 fallback 到 `recall_query` / `recall_context`。
 
 ccRecall 的價值在長尾——幾百個 session 不可能全手工整理。如果 Claude 兩邊都試，auto memory 永遠會贏（本來就在 context 裡而且已經被策展）。ccRecall 存在的意義是：策展索引漏掉時，長尾那堆還在資料庫裡可以撈出來。
+
+**ccRecall 內部從 v0.3.0 起多了一層 trust 拆分。** SessionEnd hook 寫到 low-trust `session_journal` 表——`recall_query` 不會去讀那裡。要讓某筆候選進到查詢結果，跑 `ccmem promote <id>` 升級到 high-trust `memories`。Manual `recall_save` 完全不經 journal——直接寫 memories。設計目的：讓 harvester 廣捕，但 recall 結果保持乾淨。
 
 ---
 
@@ -267,7 +307,7 @@ ccRecall/
 │   │   ├── memory-service.ts         # 記憶生命週期(touch / delete / update)
 │   │   ├── compression.ts            # L0→L1→L2→delete 狀態機
 │   │   ├── lint.ts                   # Orphan / stale 記憶偵測
-│   │   ├── maintenance-coordinator.ts # 背景壓縮 tick
+│   │   ├── maintenance-coordinator.ts # 背景壓縮 tick + journal decay sweep
 │   │   ├── watcher.ts                # chokidar JSONL watcher(Phase 4e)
 │   │   └── log-safe.ts               # scrubErrorMessage — log-injection 防護
 │   ├── api/
@@ -277,7 +317,8 @@ ccRecall/
 │   │   ├── server.ts                 # MCP stdio server 入口(含 shebang)
 │   │   └── tools.ts                  # recall_query + recall_context + recall_save
 │   ├── cli/
-│   │   └── daemon.ts                 # install-daemon / uninstall-daemon(macOS)
+│   │   ├── daemon.ts                 # install-daemon / uninstall-daemon(macOS)
+│   │   └── journal.ts                # ccmem promote / reject(v0.3.0 新增)
 │   └── index.ts                      # HTTP 入口 + 子指令分派
 ├── hooks/
 │   ├── session-start.mjs             # SessionStart 注入記憶(stdout)
@@ -287,10 +328,11 @@ ccRecall/
 │   ├── tutorial_zh.md                # 使用者教學（安裝 → MCP → 日常使用）
 │   ├── architecture_zh.md            # Daemon 設計取捨（給 contributor 看）
 │   └── launchd.md                    # macOS LaunchAgent 安裝/troubleshoot
-├── tests/                            # 475 個測試橫跨 32 檔案（parser、scanner、
+├── tests/                            # 562 個測試橫跨 37 檔案（parser、scanner、
 │   │                                 # summarizer、database、indexer、e2e、MCP、
 │   │                                 # memories、hooks、watcher、CLI、migrations、
-│   │                                 # FTS5 CJK edge cases、integrity monitor 等）
+│   │                                 # FTS5 CJK edge cases、integrity monitor、
+│   │                                 # session_journal DAO、promote+reject、sweep 等）
 │   └── fixtures/                     # 測試用 JSONL + 共用 helpers
 ├── .mcp.json.example                 # MCP client 設定範本
 └── NOTICE / SECURITY.md / CONTRIBUTING.md / CODE_OF_CONDUCT.md

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,7 +83,12 @@ If a scan is running and another event fires, we don't queue it — we set a `di
 
 `src/core/maintenance-coordinator.ts`
 
-Independent 5-minute timer, independent single-flight. Its only job: run `CompressionPipeline.runOnce({ batchSize: 50 })` — age memories, compress them in stages (raw → summary → one-liner), and delete those that haven't been accessed in 60 days.
+Independent 5-minute timer, independent single-flight. Two sweeps per tick (since v0.3.0):
+
+1. `CompressionPipeline.runOnce({ batchSize: 50 })` — age memories, compress them in stages (raw → summary → one-liner), and delete those that haven't been accessed in 60 days.
+2. `sweepJournal()` — delete journal entries that are `rejected` past their 7-day `expires_at`, plus `pending` entries older than 30 days. Promoted entries are kept indefinitely as an audit trail (the promotion already wrote a corresponding row into `memories`).
+
+Both sweeps share the coordinator's single-flight; the watcher's single-flight is separate.
 
 It does *not* share the watcher's single-flight. Here's why: the watcher writes to the session-scoped tables (`sessions` / `sessions_fts` / `session_files` / `message_uuids` / topic tables); the coordinator writes to `memories`. Disjoint tables means they can't corrupt each other's state. What they *can* do is contend for the SQLite writer (WAL serializes one writer at a time), but that's a throughput concern, not a correctness one. Keeping the single-flights per-engine means each one's worst case is bounded by itself, not by the other.
 
@@ -95,7 +100,9 @@ It does *not* share the watcher's single-flight. Here's why: the watcher writes 
 
 `src/api/routes.ts`
 
-Memories don't get created by the watcher. The watcher writes **session summaries** (into the `sessions` table); harvesting a summary *into a memory row* happens only when `/session/end` is called. That endpoint is driven by the SessionEnd hook `hooks/session-end.mjs`.
+Memories don't get created by the watcher. The watcher writes **session summaries** (into the `sessions` table); harvesting a summary into a journal candidate happens only when `/session/end` is called. That endpoint is driven by the SessionEnd hook `hooks/session-end.mjs`.
+
+Since v0.3.0 the harvest target is `session_journal`, **not** `memories`. The hook produces a low-trust candidate; turning it into a high-trust memory takes an explicit `POST /journal/promote` (typically via `ccmem promote <id>`). Manual `POST /memory/save` and the MCP `recall_save` tool still write directly to `memories` — they bypass journal entirely. Reasoning lives in the "Trust grade vs persistence gate" section below.
 
 ### Why harvest is hook-driven, not watcher-driven
 
@@ -119,6 +126,29 @@ const server = createServer(db, {
 
 The tradeoff: two concurrent `runIndexer` runs can contend for the writer. In practice they don't corrupt — SQLite WAL serializes writes — and the window is narrow (rescue only runs on cache miss).
 
+### Promote and reject paths
+
+`POST /journal/promote` runs four steps inside one BEGIN/COMMIT: `saveMemory` → `saveMemoryTopics` → `rebuildKnowledgeMap` → `promoteJournalEntry` (which sets the journal row's `status = 'promoted'` and links `promoted_memory_id`). If any step throws, the transaction rolls back and the journal row stays `pending`. `promoteJournalEntry()` returning `false` (concurrent promote race) re-throws inside the transaction so an already-written memory row does not leak — race-safe by construction, not by `SELECT … FOR UPDATE` gymnastics.
+
+`POST /journal/reject` is simpler: it sets `status = 'rejected'` and `expires_at = now + 7 days`. The decay sweep in Engine 2 reaps it later. The soft-delete + TTL choice (rather than immediate `DELETE`) means an accidental reject can be undone within a week — `UPDATE session_journal SET status = 'pending', expires_at = NULL WHERE id = ?` is enough.
+
+---
+
+## Trust grade vs persistence gate (the 0.3.0 redesign)
+
+Pre-0.3.0, the rule scorer in `summarizer.ts` decided whether the harvest got persisted at all (`score >= KNOWLEDGE_THRESHOLD`). A corpus audit on 39 known-good outcomes returned **0** over threshold — the scorer was systematically under-weighting real outcomes (the failure scenarios are catalogued in [issue #25](https://github.com/tznthou/ccRecall/issues/25)). Adding more regex patterns would have only delayed the next failure mode.
+
+The structural fix was to move the scorer off the persistence gate. Harvest now *always* lands somewhere; the scorer informs trust grade and promotion priority instead of yes/no. Two tables, two trust levels:
+
+| Table | Write path | Trust | Read path |
+|---|---|---|---|
+| `session_journal` | SessionEnd hook (auto) | Low — needs review | `/journal/pending`, `/health.journalPendingCount` |
+| `memories` | `recall_save` (manual) **or** `ccmem promote` | High — explicit human OK | `recall_query`, `recall_context`, `/memory/query` |
+
+The hard floor is preserved. The scorer's `noise` and `process-report` reasons still short-circuit (these aren't knowledge regardless of where they land), so Claude Code's session-completion summaries do not pollute the journal either.
+
+What this design buys us: harvester records broadly without polluting recall results; the user (or future tooling) can replay the trust decision later as patterns evolve, without re-running the harvester or losing data. What it costs: someone has to do the promotion. Manual-only on purpose — auto-promote at a threshold *is* the persistence gate we just removed, and would re-introduce the same failure mode. Surfacing pending count via `/health` and the full list via `/journal/pending` is the discovery mechanism.
+
 ---
 
 ## Trade-offs We Chose
@@ -130,6 +160,8 @@ The tradeoff: two concurrent `runIndexer` runs can contend for the writer. In pr
 | Three per-engine single-flights | One global lock | A global lock means compression blocks indexing and vice versa. Per-engine isolates blast radius to its own job. |
 | Hook-driven harvest | Watcher-driven harvest | Only Claude Code knows when a session *really* ends. Watcher sees file writes, not session lifecycle. |
 | Rescue bypasses single-flight | Rescue respects single-flight | Rescue is a blocking HTTP request. Getting dropped silently by the watcher's `dirty` flag would turn into a 404 to the hook. Deterministic execution wins. |
+| Two trust tiers (`session_journal` + `memories`) | Single table with a `trust` column | Disjoint tables make `recall_query` cheap and unambiguous — it never needs a `WHERE trust = 'high'` filter. Hook writes can never accidentally pollute recall, even if a future bug forgets the column. The cost — one extra table — is paid once at migration; the recall savings are amortized forever. |
+| Manual-only promotion | Auto-promote at score threshold | Auto-promote at a score threshold *is* the persistence gate we just removed. Threshold-driven persistence is what produced the 0/39 audit hit rate. Manual promotion (with `/health` surfacing) keeps the human in the loop precisely where we know the rule scorer can't be trusted alone. |
 
 ---
 
@@ -155,5 +187,9 @@ Authoritative state is always `gh issue list` plus project notes, not this file.
 | What does the summarizer produce? | `src/core/summarizer.ts:420-480` |
 | Why is `reason: 'resume'` skipped? | `hooks/session-end.mjs:82` |
 | How is compression scheduled? | `src/core/maintenance-coordinator.ts:51-57` |
+| Where is the v22 schema migration defined? | `src/core/database.ts` (grep `journalCreateSql`) |
+| How does `POST /journal/promote` stay atomic? | `src/api/routes.ts` (grep `promoteJournal`) |
+| Where does the journal decay sweep run? | `src/core/maintenance-coordinator.ts` (grep `sweepJournal`) |
+| Where is the `ccmem promote` / `reject` CLI? | `src/cli/journal.ts` |
 
 Found something the doc gets wrong, or a trade-off not explained here? Open a [GitHub Issue](https://github.com/tznthou/ccRecall/issues) — the code is the truth, and this doc should track it.

--- a/docs/architecture_zh.md
+++ b/docs/architecture_zh.md
@@ -83,7 +83,12 @@ Scan 跑到一半又來 event，我們不 queue——設一個 `dirty` flag 等�
 
 `src/core/maintenance-coordinator.ts`
 
-獨立的 5 分鐘 timer、獨立的 single-flight。它只做一件事：跑 `CompressionPipeline.runOnce({ batchSize: 50 })`——讓記憶老化、分階段壓縮（raw → summary → 一行）、60 天沒被 access 就砍。
+獨立的 5 分鐘 timer、獨立的 single-flight。每 tick 兩個 sweep（v0.3.0 起）：
+
+1. `CompressionPipeline.runOnce({ batchSize: 50 })`——讓記憶老化、分階段壓縮（raw → summary → 一行）、60 天沒被 access 就砍。
+2. `sweepJournal()`——刪掉 `rejected` 過期（7 天 `expires_at`）的 journal 條目，加上 `pending` 超過 30 天的條目。`promoted` 條目不刪，留作 audit trail（promotion 當下已經寫了一筆 `memories` row）。
+
+兩個 sweep 共用 coordinator 自己的 single-flight；watcher 那條獨立。
 
 它**不**共用 watcher 的 single-flight。為什麼：watcher 寫 `sessions/messages/topics`，coordinator 寫 `memories`。兩邊表 disjoint，不會污染彼此 state。唯一可能衝突的是 SQLite writer（WAL 一次一個 writer），但那是吞吐量問題不是正確性問題。每引擎各自 single-flight 就是讓各自最壞 case 只綁自己，不拖累別的引擎。
 
@@ -95,7 +100,9 @@ Scan 跑到一半又來 event，我們不 queue——設一個 `dirty` flag 等�
 
 `src/api/routes.ts`
 
-Memory 不是 watcher 建的。Watcher 把 **session summary** 寫進 `sessions` 表；把 summary **升級成 memory row** 只在 `/session/end` 被呼叫時才發生。這 endpoint 由 SessionEnd hook `hooks/session-end.mjs` 觸發。
+Memory 不是 watcher 建的。Watcher 把 **session summary** 寫進 `sessions` 表；把 summary 萃取成 journal 候選只在 `/session/end` 被呼叫時才發生。這 endpoint 由 SessionEnd hook `hooks/session-end.mjs` 觸發。
+
+v0.3.0 起 harvest 寫入目標是 `session_journal`，**不是** `memories`。Hook 產出的是 low-trust 候選；要變成 high-trust memory 需要顯式呼叫 `POST /journal/promote`（一般透過 `ccmem promote <id>`）。Manual `POST /memory/save` 跟 MCP `recall_save` 仍然直寫 `memories`——完全不經 journal。Rationale 見下方「Trust grade vs persistence gate」。
 
 ### 為什麼 harvest 靠 hook 不靠 watcher
 
@@ -119,6 +126,29 @@ const server = createServer(db, {
 
 取捨：兩個 `runIndexer` 同時跑可能 writer 爭用。實際上不會 corrupt——SQLite WAL 會 serialize write——而且 window 很窄（rescue 只在 cache miss 時跑）。
 
+### Promote 與 reject 路徑
+
+`POST /journal/promote` 在單一 BEGIN/COMMIT 裡跑四步：`saveMemory` → `saveMemoryTopics` → `rebuildKnowledgeMap` → `promoteJournalEntry`（後者把 journal row 設成 `status = 'promoted'` 並 link `promoted_memory_id`）。任一步 throw，transaction rollback，journal row 留在 `pending`。`promoteJournalEntry()` 回 `false`（並發 promote race）會在 transaction 內 re-throw，已經寫進去的 memory row 也跟著 rollback——race-safe by construction，不靠 `SELECT … FOR UPDATE` 把戲。
+
+`POST /journal/reject` 簡單：把 `status` 設 `rejected`、`expires_at` 設 now + 7 天。Engine 2 的 decay sweep 之後收。選 soft-delete + TTL（而不是立即 `DELETE`）的理由：誤 reject 一週內救得回來——`UPDATE session_journal SET status = 'pending', expires_at = NULL WHERE id = ?` 就好。
+
+---
+
+## Trust grade vs persistence gate（0.3.0 重設計）
+
+v0.3.0 之前，`summarizer.ts` 的 rule scorer 直接決定 harvest 是否被持久化（`score >= KNOWLEDGE_THRESHOLD`）。對 39 筆 known-good outcome 的 corpus audit 結果是 **0** 過 threshold——scorer 系統性低估真實 outcome（failure 場景整理在 [issue #25](https://github.com/tznthou/ccRecall/issues/25)）。再加 regex pattern 只會延後下次撞牆。
+
+結構性修法是把 scorer 從 persistence gate 上移開。Harvest 現在**永遠**會落地；scorer 改成提供 trust grade 與 promote 優先序，不再是 yes/no。兩張表、兩個 trust 層：
+
+| 表 | 寫入路徑 | Trust | 讀取路徑 |
+|---|---|---|---|
+| `session_journal` | SessionEnd hook（自動） | 低——需審閱 | `/journal/pending`、`/health.journalPendingCount` |
+| `memories` | `recall_save`（手動）**或** `ccmem promote` | 高——明確人工 OK | `recall_query`、`recall_context`、`/memory/query` |
+
+Hard floor 仍在。Scorer 的 `noise` 與 `process-report` reason 仍然 short-circuit（不論落到哪都不算 knowledge），所以 Claude Code 的 session 收尾摘要也不會污染 journal。
+
+這套設計買到的：harvester 廣捕、recall 結果不被污染；trust 決策可以隨 pattern 演化重放，不需重跑 harvester、不會掉資料。代價：要有人做 promotion。Manual-only by design——auto-promote at threshold *正是*我們剛剛拆掉的 persistence gate，會重蹈失敗模式。`/health` 露 pending 計數、`/journal/pending` 列完整清單，是 surfacing 機制。
+
 ---
 
 ## 我們選的取捨
@@ -130,6 +160,8 @@ const server = createServer(db, {
 | 每引擎獨立 single-flight | 一個 global lock | Global lock 會讓壓縮擋索引反之亦然。per-engine 隔離爆炸半徑 |
 | Hook-driven harvest | Watcher-driven harvest | 只有 Claude Code 知道 session 真正什麼時候結束。Watcher 看到的是檔案寫入，不是 session 生命週期 |
 | Rescue 繞 single-flight | Rescue 尊重 single-flight | Rescue 是 blocking HTTP request。被 watcher 的 `dirty` flag 默默吞掉會讓 hook 收到 404。確定執行贏過一致性 |
+| 兩個 trust 層（`session_journal` + `memories`）| 單表加一個 `trust` 欄位 | 表 disjoint 讓 `recall_query` 簡單明確——不用每次都 `WHERE trust = 'high'`。Hook 寫入永遠不會誤汙染 recall，就算未來某 bug 忘了過濾欄位也安全。代價是多一張表，遷移一次付完；recall 端的省則是永久的 |
+| 只開 manual promotion | 分數到 threshold 就 auto-promote | Auto-promote at threshold *就是*我們剛剛拆掉的 persistence gate。Threshold-driven persistence 正是 0/39 audit 的兇手。Manual promote（搭配 `/health` surfacing）讓人工留在我們已知 scorer 不可信的決策點上 |
 
 ---
 
@@ -155,5 +187,9 @@ const server = createServer(db, {
 | Summarizer 吐什麼出來 | `src/core/summarizer.ts:420-480` |
 | 為什麼 `reason: 'resume'` 要跳 | `hooks/session-end.mjs:82` |
 | Compression 怎麼排程 | `src/core/maintenance-coordinator.ts:51-57` |
+| v22 schema migration 在哪定義 | `src/core/database.ts`（grep `journalCreateSql`） |
+| `POST /journal/promote` 怎麼維持 atomic | `src/api/routes.ts`（grep `promoteJournal`） |
+| Journal decay sweep 在哪跑 | `src/core/maintenance-coordinator.ts`（grep `sweepJournal`） |
+| `ccmem promote` / `reject` CLI 在哪 | `src/cli/journal.ts` |
 
 發現本檔寫錯的地方、或某個 trade-off 沒講到？開 [GitHub Issue](https://github.com/tznthou/ccRecall/issues)——code 才是 truth，本檔只該追著它走。

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -83,7 +83,7 @@ After the three setup steps you might reasonably wonder: does it just keep runni
 4. **Hooks**
    The next section walks you through wiring these up. Once configured, Claude Code calls ccRecall at two moments automatically:
    - **SessionStart**: relevant memories are injected into Claude's context *before* your first prompt — you never have to ask it to "look something up"
-   - **SessionEnd**: the session you just finished is harvested into a new memory
+   - **SessionEnd**: the session you just finished is harvested into the **journal** — a low-trust review queue (since v0.3.0). It does *not* show up in `recall_query` until you promote it (see Scenario 4 below).
 
 The takeaway: **install + hooks = set and forget**. ccRecall accumulates on its own.
 
@@ -110,18 +110,25 @@ Remove later: `ccmem uninstall-hooks` (only deletes ccRecall's own entries; your
 
 ### Verifying the hook fires
 
+Since v0.3.0 the hook writes to `session_journal`, not `memories` — so count that table:
+
 ```bash
-# Note the current memory count
-sqlite3 ~/.ccrecall/ccrecall.db "SELECT COUNT(*) FROM memories"
+# Note the current journal count
+sqlite3 ~/.ccrecall/ccrecall.db "SELECT COUNT(*) FROM session_journal"
+
+# Or just check via /health
+curl http://127.0.0.1:7749/health | jq .journalPendingCount
 
 # Open a fresh Claude Code session, chat briefly, close it
 
-# Recount — should be +1
-sqlite3 ~/.ccrecall/ccrecall.db "SELECT COUNT(*) FROM memories"
+# Recount — should be higher
+sqlite3 ~/.ccrecall/ccrecall.db "SELECT COUNT(*) FROM session_journal"
 
 # Or tail the daemon log and watch /session/end land
 tail -f ~/Library/Logs/ccrecall/ccrecall.out.log
 ```
+
+The `memories` table count won't move from a hook fire alone — that takes a `ccmem promote` (see Scenario 4) or a manual `recall_save`.
 
 ---
 
@@ -156,7 +163,7 @@ tail -f ~/Library/Logs/ccrecall/ccrecall.out.log
 
 ---
 
-## Three Everyday Scenarios
+## Four Everyday Scenarios
 
 ### Scenario 1: Recalling "That Bug We Fixed"
 
@@ -205,6 +212,31 @@ Claude: Three main clusters:
 ```
 
 That's ccRecall's metacognition layer — not just individual memories, but topic clusters showing what you and the AI have actually been exploring together.
+
+### Scenario 4: Promoting a Journal Candidate (since v0.3.0)
+
+The SessionEnd hook records every closed session into `session_journal` — a low-trust queue that `recall_query` does not read. To make a candidate searchable, promote it:
+
+```bash
+# See what's pending review
+curl http://127.0.0.1:7749/journal/pending | jq
+
+# Picked a good one? Promote it
+ccmem promote 123
+# {"id":456,"type":"discovery","confidence":0.7}
+
+# Discard noise
+ccmem reject 124
+# Soft-deleted; cleared in 7 days by the decay sweep
+```
+
+Want a different memory type or higher confidence?
+
+```bash
+ccmem promote 123 --type decision --confidence 0.9
+```
+
+Why manual? The pre-0.3.0 design gated harvest on a rule scorer — corpus audit found a 0/39 hit rate on real outcomes (the scorer kept under-weighting them). The fix isn't more regex patterns; it's letting the harvester record broadly and letting you decide what's worth keeping. See [issue #21](https://github.com/tznthou/ccRecall/issues/21) for the full reasoning.
 
 ---
 

--- a/docs/tutorial_zh.md
+++ b/docs/tutorial_zh.md
@@ -83,7 +83,7 @@ claude mcp add ccrecall --scope user -- ccmem-mcp
 4. **Hooks（Claude Code 生命週期鉤子）**
    下一節會教你設 hook。設好之後 Claude Code 會在兩個時機自動叫 ccRecall：
    - **SessionStart**：開新 session 前，把相關記憶注入 context（Claude 不用自己決定要不要查）
-   - **SessionEnd**：session 結束時，把剛剛這段萃取成一筆新的 memory
+   - **SessionEnd**：session 結束時，把剛剛這段寫進 **journal**——v0.3.0 之後是 low-trust 待審佇列，**不會**直接被 `recall_query` 召回，要先 promote（見下方情境四）
 
 一句話：**裝完 + 配好 hook，之後就不用管，它自己累積。**
 
@@ -110,18 +110,25 @@ ccmem install-hooks
 
 ### 驗證 hook 真的有觸發
 
+v0.3.0 之後 hook 是寫到 `session_journal`，不是 `memories`，所以要數那張表：
+
 ```bash
-# 記下目前 memory 數
-sqlite3 ~/.ccrecall/ccrecall.db "SELECT COUNT(*) FROM memories"
+# 記下目前 journal 數
+sqlite3 ~/.ccrecall/ccrecall.db "SELECT COUNT(*) FROM session_journal"
+
+# 或直接看 /health
+curl http://127.0.0.1:7749/health | jq .journalPendingCount
 
 # 開新 Claude Code session，聊幾句，關掉
 
-# 再數一次，應該 +1
-sqlite3 ~/.ccrecall/ccrecall.db "SELECT COUNT(*) FROM memories"
+# 再數一次，應該變多
+sqlite3 ~/.ccrecall/ccrecall.db "SELECT COUNT(*) FROM session_journal"
 
 # 或者 tail daemon log 看 /session/end 被打到
 tail -f ~/Library/Logs/ccrecall/ccrecall.out.log
 ```
+
+光靠 hook 觸發 `memories` 表的數字不會動——要 `ccmem promote`（見情境四）或 manual `recall_save` 才會。
 
 ---
 
@@ -156,7 +163,7 @@ tail -f ~/Library/Logs/ccrecall/ccrecall.out.log
 
 ---
 
-## 日常三情境
+## 日常四情境
 
 ### 情境一：跨 session 召回「上次那個 bug」
 
@@ -203,6 +210,31 @@ Claude：三大 cluster：
 ```
 
 這是 ccRecall 的元認知層——不只記個別 memory，還會聚合成「你跟 AI 在這個 project 討論過什麼 topic」。
+
+### 情境四：把 journal 候選 promote 到 memories（v0.3.0 新增）
+
+SessionEnd hook 把每個結束的 session 寫進 `session_journal`——這是 low-trust 待審佇列，`recall_query` 不會去讀。要讓某筆候選變成可查詢，promote 它：
+
+```bash
+# 看待審清單
+curl http://127.0.0.1:7749/journal/pending | jq
+
+# 挑到喜歡的就 promote
+ccmem promote 123
+# {"id":456,"type":"discovery","confidence":0.7}
+
+# 看到雜訊就 reject
+ccmem reject 124
+# soft-delete，7 天 TTL 後由 decay sweep 清掉
+```
+
+想換 type 或調 confidence？
+
+```bash
+ccmem promote 123 --type decision --confidence 0.9
+```
+
+為什麼要手動？v0.3.0 之前的設計把 rule scorer 卡在 harvest 持久化 gate 上——corpus audit 顯示對真實 outcome 的命中率是 0/39（scorer 一直低估）。修法不是再加 regex patterns，是讓 harvester 廣捕，讓你決定值不值得留。完整 rationale 見 [issue #21](https://github.com/tznthou/ccRecall/issues/21)。
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tznthou/ccrecall",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "description": "AI memory service for Claude Code — on-demand context injection with metacognition",
   "type": "module",
   "main": "dist/index.js",

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -6,9 +6,11 @@ import type { Database, MemoryInput } from '../core/database.js'
 import { MemoryService } from '../core/memory-service.js'
 import { runLint } from '../core/lint.js'
 import { scrubErrorMessage } from '../core/log-safe.js'
+import { scoreKnowledgeBearing } from '../core/outcome-scorer.js'
 import type {
   HealthResult, Memory, MemoryType, SessionMeta, OutcomeStatus,
   KnowledgeDepth, Topic, TopicDetail, MetacognitionSummary, CheckpointResult,
+  JournalEntryInput,
 } from '../core/types.js'
 import { deriveDepth } from '../core/types.js'
 import type { IntegrityCheckRecord } from '../core/integrity-monitor.js'
@@ -78,18 +80,26 @@ export function inferConfidence(outcome: OutcomeStatus): number {
   return 0.7
 }
 
-export function buildMemoryFromSession(session: SessionMeta): MemoryInput | null {
+/** P1 (#21): hook auto-harvester 改寫 session_journal 不寫 memories;
+ *  manual recall_save 仍直寫 memories。promote 路徑 (C4) 會把 journal entry
+ *  搬到 memories table 並設 confidence。
+ *
+ *  Score 重算: summarizer 已用 scorer 過 noise/process-report hard floor,
+ *  但 score + reasons metadata 沒儲在 sessions.harvest_text。重算成本低
+ *  (regex 對 <2KB 文字),換 schema 不變的代價可接受。 */
+export function buildJournalCandidate(session: SessionMeta): JournalEntryInput | null {
   const harvestText = session.harvestText?.trim()
   if (!harvestText) return null
+  const result = scoreKnowledgeBearing(harvestText)
+  // Defense in depth: 單元測試可能直接餵 SessionMeta, hard floor 仍應生效。
+  if (result.reasons.includes('noise') || result.reasons.includes('process-report')) return null
   return {
     sessionId: session.id,
     messageId: null,
     content: harvestText,
-    // Source switched from first-user-prompt to scored outcome cluster (#18).
-    // type='query' is a provenance marker; semantic kind (decision/discovery)
-    // stays the realm of explicit recall_save until #21 splits source vs kind.
-    type: 'query',
-    confidence: inferConfidence(session.outcomeStatus),
+    score: result.score,
+    reasonsJson: JSON.stringify(result.reasons),
+    projectId: session.projectId ?? null,
   }
 }
 
@@ -328,49 +338,30 @@ export function createRequestHandler(
         sendJson(res, 404, { error: 'session not found' })
         return
       }
-      const candidate = buildMemoryFromSession(session)
+      const candidate = buildJournalCandidate(session)
       if (!candidate) {
         sendJson(res, 200, {
           ok: true,
           sessionId: v.sessionId,
-          memoriesSaved: [],
+          journalSaved: [],
           dryRun: v.dryRun,
-          reason: 'session has no summary',
+          reason: 'session has no harvest candidate',
         })
         return
       }
 
-      const existing = db.getMemoriesBySessionId(v.sessionId)
-      if (existing.length > 0) {
-        sendJson(res, 200, {
-          ok: true,
-          sessionId: v.sessionId,
-          memoriesSaved: existing.map(m => m.id),
-          dryRun: v.dryRun,
-          alreadyHarvested: true,
-          candidate: v.dryRun ? candidate : undefined,
-        })
-        return
-      }
-
+      // P1 (#21): journal 用 content_hash UNIQUE INDEX dedup; saveJournalEntry
+      // 在重複 hash 時回 0。不再需要 v0.2.x 的 alreadyHarvested split-brain check;
+      // memory_topics / rebuildKnowledgeMap 留給 promote 路徑 (C4) 處理。
       const savedIds: number[] = []
       if (!v.dryRun) {
-        // Atomic：若 saveMemoryTopics 或 rebuildKnowledgeMap 失敗，整個 harvest rollback，
-        // 避免 retry 時 existing.length > 0 回 alreadyHarvested 但 topic 關聯缺失的 split-brain
-        db.runTransaction(() => {
-          const memoryId = db.saveMemory(candidate)
-          savedIds.push(memoryId)
-          const sessionTopics = db.getSessionTopicKeys(session.id)
-          if (sessionTopics.length > 0) {
-            db.saveMemoryTopics(memoryId, session.projectId, sessionTopics)
-          }
-          db.rebuildKnowledgeMap(session.projectId)
-        })
+        const id = db.saveJournalEntry(candidate)
+        if (id > 0) savedIds.push(id)
       }
       sendJson(res, 200, {
         ok: true,
         sessionId: v.sessionId,
-        memoriesSaved: savedIds,
+        journalSaved: savedIds,
         dryRun: v.dryRun,
         candidate: v.dryRun ? candidate : undefined,
       })

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -205,6 +205,7 @@ export function createRequestHandler(
         sessionCount: db.getMainSessionCount(),
         memoryCount: db.getMemoryCount(),
         topicCount: db.getTopicCount(),
+        journalPendingCount: db.getJournalPendingCount(),
         uptime: Math.floor((Date.now() - startTime) / 1000),
         lastIntegrityCheckAt: integrity?.at ?? null,
         lastIntegrityCheckOk: integrity?.ok ?? null,

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import http from 'node:http'
 import { URL } from 'node:url'
-import { sendJson, readBody } from './server.js'
+import { sendJson, parseJsonBody } from './server.js'
 import type { Database, MemoryInput } from '../core/database.js'
 import { MemoryService } from '../core/memory-service.js'
 import { runLint } from '../core/lint.js'
@@ -266,25 +266,9 @@ export function createRequestHandler(
         sendJson(res, 403, { error: 'cross-origin requests forbidden' })
         return
       }
-      let bodyText: string
-      try {
-        bodyText = await readBody(req)
-      } catch (err) {
-        const msg = (err as Error).message
-        if (msg === 'body too large') {
-          sendJson(res, 413, { error: msg })
-          return
-        }
-        throw err
-      }
-      let parsed: unknown
-      try {
-        parsed = bodyText ? JSON.parse(bodyText) : {}
-      } catch {
-        sendJson(res, 400, { error: 'invalid JSON body' })
-        return
-      }
-      const v = validateSaveBody(parsed)
+      const body = await parseJsonBody(req, res)
+      if (!body.ok) return
+      const v = validateSaveBody(body.parsed)
       if ('error' in v) {
         sendJson(res, 400, v)
         return
@@ -300,18 +284,9 @@ export function createRequestHandler(
         sendJson(res, 403, { error: 'cross-origin requests forbidden' })
         return
       }
-      let bodyText: string
-      try {
-        bodyText = await readBody(req)
-      } catch (err) {
-        const msg = (err as Error).message
-        if (msg === 'body too large') { sendJson(res, 413, { error: msg }); return }
-        throw err
-      }
-      let parsed: unknown
-      try { parsed = bodyText ? JSON.parse(bodyText) : {} }
-      catch { sendJson(res, 400, { error: 'invalid JSON body' }); return }
-      const b = parsed as { id?: unknown; type?: unknown; confidence?: unknown }
+      const body = await parseJsonBody(req, res)
+      if (!body.ok) return
+      const b = body.parsed as { id?: unknown; type?: unknown; confidence?: unknown }
       if (typeof b.id !== 'number' || !Number.isInteger(b.id) || b.id <= 0) {
         sendJson(res, 400, { error: 'id must be positive integer' })
         return
@@ -396,18 +371,9 @@ export function createRequestHandler(
         sendJson(res, 403, { error: 'cross-origin requests forbidden' })
         return
       }
-      let bodyText: string
-      try {
-        bodyText = await readBody(req)
-      } catch (err) {
-        const msg = (err as Error).message
-        if (msg === 'body too large') { sendJson(res, 413, { error: msg }); return }
-        throw err
-      }
-      let parsed: unknown
-      try { parsed = bodyText ? JSON.parse(bodyText) : {} }
-      catch { sendJson(res, 400, { error: 'invalid JSON body' }); return }
-      const b = parsed as { id?: unknown }
+      const body = await parseJsonBody(req, res)
+      if (!body.ok) return
+      const b = body.parsed as { id?: unknown }
       if (typeof b.id !== 'number' || !Number.isInteger(b.id) || b.id <= 0) {
         sendJson(res, 400, { error: 'id must be positive integer' })
         return
@@ -429,25 +395,9 @@ export function createRequestHandler(
         sendJson(res, 403, { error: 'cross-origin requests forbidden' })
         return
       }
-      let bodyText: string
-      try {
-        bodyText = await readBody(req)
-      } catch (err) {
-        const msg = (err as Error).message
-        if (msg === 'body too large') {
-          sendJson(res, 413, { error: msg })
-          return
-        }
-        throw err
-      }
-      let parsed: unknown
-      try {
-        parsed = bodyText ? JSON.parse(bodyText) : {}
-      } catch {
-        sendJson(res, 400, { error: 'invalid JSON body' })
-        return
-      }
-      const v = validateSessionEndBody(parsed)
+      const body = await parseJsonBody(req, res)
+      if (!body.ok) return
+      const v = validateSessionEndBody(body.parsed)
       if ('error' in v) {
         sendJson(res, 400, v)
         return
@@ -558,25 +508,9 @@ export function createRequestHandler(
         sendJson(res, 403, { error: 'cross-origin requests forbidden' })
         return
       }
-      let bodyText: string
-      try {
-        bodyText = await readBody(req)
-      } catch (err) {
-        const msg = (err as Error).message
-        if (msg === 'body too large') {
-          sendJson(res, 413, { error: msg })
-          return
-        }
-        throw err
-      }
-      let parsed: unknown
-      try {
-        parsed = bodyText ? JSON.parse(bodyText) : {}
-      } catch {
-        sendJson(res, 400, { error: 'invalid JSON body' })
-        return
-      }
-      const v = validateCheckpointBody(parsed)
+      const body = await parseJsonBody(req, res)
+      if (!body.ok) return
+      const v = validateCheckpointBody(body.parsed)
       if ('error' in v) {
         sendJson(res, 400, v)
         return

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -293,6 +293,109 @@ export function createRequestHandler(
       return
     }
 
+    // POST /journal/promote — manual promote a journal entry to memories (#21 P1)
+    if (req.method === 'POST' && path === '/journal/promote') {
+      if (!isLoopbackOrigin(req.headers.origin)) {
+        sendJson(res, 403, { error: 'cross-origin requests forbidden' })
+        return
+      }
+      let bodyText: string
+      try {
+        bodyText = await readBody(req)
+      } catch (err) {
+        const msg = (err as Error).message
+        if (msg === 'body too large') { sendJson(res, 413, { error: msg }); return }
+        throw err
+      }
+      let parsed: unknown
+      try { parsed = bodyText ? JSON.parse(bodyText) : {} }
+      catch { sendJson(res, 400, { error: 'invalid JSON body' }); return }
+      const b = parsed as { id?: unknown; type?: unknown; confidence?: unknown }
+      if (typeof b.id !== 'number' || !Number.isInteger(b.id) || b.id <= 0) {
+        sendJson(res, 400, { error: 'id must be positive integer' })
+        return
+      }
+      const type: MemoryType = (typeof b.type === 'string' && VALID_MEMORY_TYPES.has(b.type as MemoryType))
+        ? b.type as MemoryType
+        : 'discovery'
+      let confidence = 0.7
+      if (b.confidence != null) {
+        if (typeof b.confidence !== 'number' || b.confidence < 0 || b.confidence > 1) {
+          sendJson(res, 400, { error: 'confidence must be number in [0, 1]' })
+          return
+        }
+        confidence = b.confidence
+      }
+      const entry = db.getJournalEntry(b.id)
+      if (!entry) {
+        sendJson(res, 404, { error: 'journal entry not found' })
+        return
+      }
+      if (entry.status !== 'pending') {
+        sendJson(res, 409, { error: `journal entry status='${entry.status}', expected 'pending'` })
+        return
+      }
+
+      let memoryId = 0
+      db.runTransaction(() => {
+        memoryId = db.saveMemory({
+          sessionId: entry.sessionId,
+          messageId: entry.messageId,
+          content: entry.content,
+          type,
+          confidence,
+          projectId: entry.projectId,
+        })
+        // 繼承 session topics → memory_topics, 重建 knowledge_map (對齊 v0.2.x harvest 行為)
+        if (entry.sessionId) {
+          const session = db.getSessionById(entry.sessionId)
+          if (session) {
+            const sessionTopics = db.getSessionTopicKeys(session.id)
+            if (sessionTopics.length > 0) {
+              db.saveMemoryTopics(memoryId, session.projectId, sessionTopics)
+            }
+            db.rebuildKnowledgeMap(session.projectId)
+          }
+        }
+        db.promoteJournalEntry(entry.id, memoryId)
+      })
+      sendJson(res, 200, { ok: true, memoryId, journalId: entry.id })
+      return
+    }
+
+    // POST /journal/reject — mark a journal entry as rejected (decay sweep cleans up)
+    if (req.method === 'POST' && path === '/journal/reject') {
+      if (!isLoopbackOrigin(req.headers.origin)) {
+        sendJson(res, 403, { error: 'cross-origin requests forbidden' })
+        return
+      }
+      let bodyText: string
+      try {
+        bodyText = await readBody(req)
+      } catch (err) {
+        const msg = (err as Error).message
+        if (msg === 'body too large') { sendJson(res, 413, { error: msg }); return }
+        throw err
+      }
+      let parsed: unknown
+      try { parsed = bodyText ? JSON.parse(bodyText) : {} }
+      catch { sendJson(res, 400, { error: 'invalid JSON body' }); return }
+      const b = parsed as { id?: unknown }
+      if (typeof b.id !== 'number' || !Number.isInteger(b.id) || b.id <= 0) {
+        sendJson(res, 400, { error: 'id must be positive integer' })
+        return
+      }
+      // Decay TTL: 7 days; sweep cron (C5) cleans up after expires_at
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
+      const ok = db.rejectJournalEntry(b.id, expiresAt)
+      if (!ok) {
+        sendJson(res, 404, { error: 'journal entry not found or not pending' })
+        return
+      }
+      sendJson(res, 200, { ok: true, journalId: b.id, expiresAt })
+      return
+    }
+
     // POST /session/end
     if (req.method === 'POST' && path === '/session/end') {
       if (!isLoopbackOrigin(req.headers.origin)) {

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -338,29 +338,55 @@ export function createRequestHandler(
       }
 
       let memoryId = 0
-      db.runTransaction(() => {
-        memoryId = db.saveMemory({
-          sessionId: entry.sessionId,
-          messageId: entry.messageId,
-          content: entry.content,
-          type,
-          confidence,
-          projectId: entry.projectId,
-        })
-        // 繼承 session topics → memory_topics, 重建 knowledge_map (對齊 v0.2.x harvest 行為)
-        if (entry.sessionId) {
-          const session = db.getSessionById(entry.sessionId)
-          if (session) {
-            const sessionTopics = db.getSessionTopicKeys(session.id)
-            if (sessionTopics.length > 0) {
-              db.saveMemoryTopics(memoryId, session.projectId, sessionTopics)
+      try {
+        db.runTransaction(() => {
+          memoryId = db.saveMemory({
+            sessionId: entry.sessionId,
+            messageId: entry.messageId,
+            content: entry.content,
+            type,
+            confidence,
+            projectId: entry.projectId,
+          })
+          // 繼承 session topics → memory_topics, 重建 knowledge_map (對齊 v0.2.x harvest 行為)
+          if (entry.sessionId) {
+            const session = db.getSessionById(entry.sessionId)
+            if (session) {
+              const sessionTopics = db.getSessionTopicKeys(session.id)
+              if (sessionTopics.length > 0) {
+                db.saveMemoryTopics(memoryId, session.projectId, sessionTopics)
+              }
+              db.rebuildKnowledgeMap(session.projectId)
             }
-            db.rebuildKnowledgeMap(session.projectId)
           }
+          // Race guard: pre-read 後 status 若被改 (multi-daemon, 直接 SQL),
+          // promoteJournalEntry 會回 false; throw 觸發 transaction rollback,
+          // 避免 memories 多一筆 orphan 而 journal status 沒翻 promoted。
+          if (!db.promoteJournalEntry(entry.id, memoryId)) {
+            throw new Error('JOURNAL_RACE: status changed during transaction')
+          }
+        })
+      } catch (err) {
+        if ((err as Error).message?.startsWith('JOURNAL_RACE:')) {
+          sendJson(res, 409, { error: 'journal entry status changed during transaction; re-fetch and retry' })
+          return
         }
-        db.promoteJournalEntry(entry.id, memoryId)
-      })
+        throw err
+      }
       sendJson(res, 200, { ok: true, memoryId, journalId: entry.id })
+      return
+    }
+
+    // GET /journal/pending?limit=N — list pending journal entries for promote/reject (#21 P1 fix-up)
+    if (req.method === 'GET' && path === '/journal/pending') {
+      if (!isLoopbackOrigin(req.headers.origin)) {
+        sendJson(res, 403, { error: 'cross-origin requests forbidden' })
+        return
+      }
+      const rawLimit = parseInt(url.searchParams.get('limit') ?? '20', 10)
+      const limit = Number.isNaN(rawLimit) || rawLimit < 1 ? 20 : Math.min(rawLimit, 100)
+      const entries = db.getPendingJournalEntries(limit)
+      sendJson(res, 200, { entries, total: entries.length })
       return
     }
 

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -2,6 +2,7 @@
 import http from 'node:http'
 import type { Database } from '../core/database.js'
 import { createRequestHandler, type RequestHandlerOptions } from './routes.js'
+import { scrubErrorMessage } from '../core/log-safe.js'
 
 export function createServer(db: Database, opts: RequestHandlerOptions = {}): http.Server {
   const handleRequest = createRequestHandler(db, opts)
@@ -10,7 +11,10 @@ export function createServer(db: Database, opts: RequestHandlerOptions = {}): ht
     try {
       await handleRequest(req, res)
     } catch (err) {
-      console.error('Unhandled error:', err)
+      // scrub before logging: SQLite errors can embed user-harvested content
+      // (e.g. journal entry.content via constraint violations) that may carry
+      // ANSI / CR control bytes. Pattern matches every other error log site.
+      console.error('Unhandled error:', scrubErrorMessage(err))
       sendJson(res, 500, { error: 'Internal server error' })
     }
   })

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -44,3 +44,30 @@ export function readBody(req: http.IncomingMessage): Promise<string> {
     req.on('error', reject)
   })
 }
+
+/** Read + JSON-parse a request body. On size overflow sends 413, on parse
+ *  error sends 400, then returns { ok: false } so the caller can early-return.
+ *  The ok branch returns parsed (object/null/array — same shape as JSON.parse).
+ *  Empty body parses as {} so endpoint validators see the no-keys case. */
+export async function parseJsonBody(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<{ ok: true; parsed: unknown } | { ok: false }> {
+  let bodyText: string
+  try {
+    bodyText = await readBody(req)
+  } catch (err) {
+    const msg = (err as Error).message
+    if (msg === 'body too large') {
+      sendJson(res, 413, { error: msg })
+      return { ok: false }
+    }
+    throw err
+  }
+  try {
+    return { ok: true, parsed: bodyText ? JSON.parse(bodyText) : {} }
+  } catch {
+    sendJson(res, 400, { error: 'invalid JSON body' })
+    return { ok: false }
+  }
+}

--- a/src/cli/journal.ts
+++ b/src/cli/journal.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+import http from 'node:http'
+
+const DEFAULT_PORT = 7749
+
+export interface PromoteOptions {
+  type?: string
+  confidence?: number
+}
+
+function getPort(): number {
+  const raw = parseInt(process.env.CCRECALL_PORT ?? String(DEFAULT_PORT), 10)
+  return Number.isFinite(raw) && raw > 0 && raw <= 65535 ? raw : DEFAULT_PORT
+}
+
+interface JsonResponse<T> {
+  status: number
+  body: T
+}
+
+function postJson<T>(reqPath: string, payload: unknown): Promise<JsonResponse<T>> {
+  return new Promise((resolve, reject) => {
+    const port = getPort()
+    const data = JSON.stringify(payload)
+    const req = http.request({
+      hostname: '127.0.0.1', port, path: reqPath, method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(data),
+      },
+    }, (res) => {
+      const chunks: Buffer[] = []
+      res.on('data', (chunk: Buffer) => chunks.push(chunk))
+      res.on('end', () => {
+        try {
+          const parsed = JSON.parse(Buffer.concat(chunks).toString()) as T
+          resolve({ status: res.statusCode ?? 0, body: parsed })
+        } catch (err) { reject(err as Error) }
+      })
+      res.on('error', reject)
+    })
+    req.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'ECONNREFUSED') {
+        reject(new Error(`Cannot connect to daemon on 127.0.0.1:${port}. Is ccRecall daemon running?`))
+      } else {
+        reject(err)
+      }
+    })
+    req.write(data)
+    req.end()
+  })
+}
+
+export function parsePromoteFlags(args: string[]): { idStr?: string; opts: PromoteOptions } {
+  let idStr: string | undefined
+  const opts: PromoteOptions = {}
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]
+    if (a === '--type' && i + 1 < args.length) {
+      opts.type = args[++i]
+    } else if (a === '--confidence' && i + 1 < args.length) {
+      const c = parseFloat(args[++i])
+      if (Number.isFinite(c)) opts.confidence = c
+    } else if (!a.startsWith('--') && idStr === undefined) {
+      idStr = a
+    }
+  }
+  return { idStr, opts }
+}
+
+export async function runPromote(idStr: string | undefined, opts: PromoteOptions = {}): Promise<number> {
+  if (!idStr) {
+    console.error('Usage: ccmem promote <journal_id> [--type discovery|decision|...] [--confidence 0.7]')
+    return 1
+  }
+  const id = parseInt(idStr, 10)
+  if (!Number.isInteger(id) || id <= 0) {
+    console.error(`Invalid id: ${idStr}`)
+    return 1
+  }
+  try {
+    const { status, body } = await postJson<{
+      ok?: boolean; memoryId?: number; journalId?: number; error?: string
+    }>('/journal/promote', { id, type: opts.type, confidence: opts.confidence })
+    if (status === 200 && body.ok) {
+      console.log(`Promoted journal #${body.journalId} → memory #${body.memoryId}`)
+      return 0
+    }
+    console.error(`promote failed (${status}): ${body.error ?? 'unknown error'}`)
+    return 1
+  } catch (err) {
+    console.error((err as Error).message)
+    return 1
+  }
+}
+
+export async function runReject(idStr: string | undefined): Promise<number> {
+  if (!idStr) {
+    console.error('Usage: ccmem reject <journal_id>')
+    return 1
+  }
+  const id = parseInt(idStr, 10)
+  if (!Number.isInteger(id) || id <= 0) {
+    console.error(`Invalid id: ${idStr}`)
+    return 1
+  }
+  try {
+    const { status, body } = await postJson<{
+      ok?: boolean; journalId?: number; expiresAt?: string; error?: string
+    }>('/journal/reject', { id })
+    if (status === 200 && body.ok) {
+      console.log(`Rejected journal #${body.journalId} — expires ${body.expiresAt}`)
+      return 0
+    }
+    console.error(`reject failed (${status}): ${body.error ?? 'unknown error'}`)
+    return 1
+  } catch (err) {
+    console.error((err as Error).message)
+    return 1
+  }
+}

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -757,6 +757,11 @@ const migrations: Migration[] = [
         )
       }
 
+      // UNIQUE 是 (session_id, content_hash) 不是 content_hash global —— 同
+      // session 重 trigger session/end 仍 dedup; 但兩個不同 session 產生同樣
+      // outcome cluster 各自存一筆 (Codex review 抓到的 cross-session leakage)。
+      // SQLite UNIQUE on nullable column: NULL 互不相等, 所以 sessionId=null 多筆
+      // 不會撞 (manual recall_save 走 memories 不會走這條, 影響面小)。
       db.exec(`
         CREATE TABLE session_journal (
           id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -773,7 +778,7 @@ const migrations: Migration[] = [
           created_at TEXT NOT NULL DEFAULT (datetime('now'))
         );
         CREATE INDEX idx_journal_status ON session_journal(status, expires_at);
-        CREATE UNIQUE INDEX idx_journal_hash ON session_journal(content_hash);
+        CREATE UNIQUE INDEX idx_journal_session_hash ON session_journal(session_id, content_hash);
       `)
     },
   },
@@ -1705,6 +1710,47 @@ export class Database {
       WHERE id = ? AND status = 'pending'
     `).run(memoryId, id)
     return info.changes > 0
+  }
+
+  /** List pending journal entries (newest first) with content preview for
+   *  surfacing on the manual promotion path. content 截 200 chars 避免 response
+   *  blob 過大; caller 想看完整內容可走 promote 看 memories 或直接 sqlite3。 */
+  getPendingJournalEntries(limit: number): Array<{
+    id: number
+    sessionId: string | null
+    score: number
+    reasonsJson: string | null
+    contentPreview: string
+    projectId: string | null
+    createdAt: string
+  }> {
+    const cappedLimit = Math.min(Math.max(limit, 1), 100)
+    const rows = this.db.prepare(`
+      SELECT id, session_id, score, reasons_json,
+             substr(content, 1, 200) AS content_preview,
+             project_id, created_at
+      FROM session_journal
+      WHERE status = 'pending'
+      ORDER BY created_at DESC, id DESC
+      LIMIT ?
+    `).all(cappedLimit) as Array<{
+      id: number
+      session_id: string | null
+      score: number
+      reasons_json: string | null
+      content_preview: string
+      project_id: string | null
+      created_at: string
+    }>
+    return rows.map(r => ({
+      id: r.id,
+      sessionId: r.session_id,
+      score: r.score,
+      reasonsJson: r.reasons_json,
+      contentPreview: r.content_preview,
+      projectId: r.project_id,
+      createdAt: r.created_at,
+    }))
   }
 
   /** 標記 entry 為 rejected, expires_at 設為 now+7d (decay sweep 才真的刪除)。

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -1620,6 +1620,11 @@ export class Database {
   // ─────────────────────────────────────────────────────────────
   // session_journal DAO (issue #21 P1)
   // 低信任 harvest 候選的寫入入口; manual recall_save 仍走 saveMemory()。
+  //
+  // Trust boundary: queryMemories / getMemoriesByTopics 故意只查 memories table,
+  // 不 union session_journal — unpromoted journal entries 是 low-trust,不該污染
+  // recall 結果。promote 路徑 (C4) 把 journal entry 搬到 memories 後才會被 recall
+  // 看到。若未來修改 query 邏輯需動到 journal,務必保持這條 invariant。
   // ─────────────────────────────────────────────────────────────
 
   /** 寫入 journal 條目。content_hash 內部以 SHA-256 計算; 同 hash 第二次 INSERT

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -3,7 +3,7 @@ import BetterSqlite3 from 'better-sqlite3'
 import { createHash } from 'node:crypto'
 import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
 import path from 'node:path'
-import type { Project, SessionMeta, SearchOptions, SessionSearchPage, SessionFile, FileOperation, OutcomeStatus, FileHistoryEntry, SubagentSession, SessionFileInput, Memory, MemoryType, Topic, SessionCheckpoint, JournalEntry, JournalEntryInput, JournalStatus } from './types.js'
+import type { Project, SessionMeta, SearchOptions, SessionSearchPage, SessionFile, FileOperation, OutcomeStatus, FileHistoryEntry, SubagentSession, SessionFileInput, Memory, MemoryType, Topic, SessionCheckpoint, JournalEntry, JournalEntryInput, JournalEntryPreview, JournalStatus } from './types.js'
 import { scrubErrorMessage } from './log-safe.js'
 
 /** 寫入 memories 時使用的參數型別 */
@@ -200,6 +200,60 @@ function mapCheckpointRow(r: CheckpointRow): SessionCheckpoint {
     sessionId: r.session_id,
     projectId: r.project_id,
     snapshotText: r.snapshot_text,
+    createdAt: r.created_at,
+  }
+}
+
+interface JournalRow {
+  id: number
+  session_id: string | null
+  message_id: string | null
+  content: string
+  content_hash: string
+  score: number
+  reasons_json: string | null
+  status: string
+  expires_at: string | null
+  promoted_memory_id: number | null
+  project_id: string | null
+  created_at: string
+}
+
+function mapJournalRow(r: JournalRow): JournalEntry {
+  return {
+    id: r.id,
+    sessionId: r.session_id,
+    messageId: r.message_id,
+    content: r.content,
+    contentHash: r.content_hash,
+    score: r.score,
+    reasonsJson: r.reasons_json,
+    status: r.status as JournalStatus,
+    expiresAt: r.expires_at,
+    promotedMemoryId: r.promoted_memory_id,
+    projectId: r.project_id,
+    createdAt: r.created_at,
+  }
+}
+
+interface JournalPreviewRow {
+  id: number
+  session_id: string | null
+  score: number
+  reasons_json: string | null
+  content_preview: string
+  project_id: string | null
+  created_at: string
+}
+
+function mapJournalPreviewRow(r: JournalPreviewRow): JournalEntryPreview {
+  return {
+    id: r.id,
+    sessionId: r.session_id,
+    score: r.score,
+    reasonsJson: r.reasons_json,
+    contentPreview: r.content_preview,
+    projectId: r.project_id,
     createdAt: r.created_at,
   }
 }
@@ -1669,35 +1723,8 @@ export class Database {
              reasons_json, status, expires_at, promoted_memory_id,
              project_id, created_at
       FROM session_journal WHERE id = ?
-    `).get(id) as {
-      id: number
-      session_id: string | null
-      message_id: string | null
-      content: string
-      content_hash: string
-      score: number
-      reasons_json: string | null
-      status: string
-      expires_at: string | null
-      promoted_memory_id: number | null
-      project_id: string | null
-      created_at: string
-    } | undefined
-    if (!row) return null
-    return {
-      id: row.id,
-      sessionId: row.session_id,
-      messageId: row.message_id,
-      content: row.content,
-      contentHash: row.content_hash,
-      score: row.score,
-      reasonsJson: row.reasons_json,
-      status: row.status as JournalStatus,
-      expiresAt: row.expires_at,
-      promotedMemoryId: row.promoted_memory_id,
-      projectId: row.project_id,
-      createdAt: row.created_at,
-    }
+    `).get(id) as JournalRow | undefined
+    return row ? mapJournalRow(row) : null
   }
 
   /** 升級 journal entry 為 promoted; caller 已透過 saveMemory 寫入 memories table
@@ -1715,15 +1742,7 @@ export class Database {
   /** List pending journal entries (newest first) with content preview for
    *  surfacing on the manual promotion path. content 截 200 chars 避免 response
    *  blob 過大; caller 想看完整內容可走 promote 看 memories 或直接 sqlite3。 */
-  getPendingJournalEntries(limit: number): Array<{
-    id: number
-    sessionId: string | null
-    score: number
-    reasonsJson: string | null
-    contentPreview: string
-    projectId: string | null
-    createdAt: string
-  }> {
+  getPendingJournalEntries(limit: number): JournalEntryPreview[] {
     const cappedLimit = Math.min(Math.max(limit, 1), 100)
     const rows = this.db.prepare(`
       SELECT id, session_id, score, reasons_json,
@@ -1733,24 +1752,8 @@ export class Database {
       WHERE status = 'pending'
       ORDER BY created_at DESC, id DESC
       LIMIT ?
-    `).all(cappedLimit) as Array<{
-      id: number
-      session_id: string | null
-      score: number
-      reasons_json: string | null
-      content_preview: string
-      project_id: string | null
-      created_at: string
-    }>
-    return rows.map(r => ({
-      id: r.id,
-      sessionId: r.session_id,
-      score: r.score,
-      reasonsJson: r.reasons_json,
-      contentPreview: r.content_preview,
-      projectId: r.project_id,
-      createdAt: r.created_at,
-    }))
+    `).all(cappedLimit) as JournalPreviewRow[]
+    return rows.map(mapJournalPreviewRow)
   }
 
   /** 標記 entry 為 rejected, expires_at 設為 now+7d (decay sweep 才真的刪除)。

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -3,7 +3,7 @@ import BetterSqlite3 from 'better-sqlite3'
 import { createHash } from 'node:crypto'
 import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
 import path from 'node:path'
-import type { Project, SessionMeta, SearchOptions, SessionSearchPage, SessionFile, FileOperation, OutcomeStatus, FileHistoryEntry, SubagentSession, SessionFileInput, Memory, MemoryType, Topic, SessionCheckpoint, JournalEntryInput } from './types.js'
+import type { Project, SessionMeta, SearchOptions, SessionSearchPage, SessionFile, FileOperation, OutcomeStatus, FileHistoryEntry, SubagentSession, SessionFileInput, Memory, MemoryType, Topic, SessionCheckpoint, JournalEntry, JournalEntryInput, JournalStatus } from './types.js'
 import { scrubErrorMessage } from './log-safe.js'
 
 /** 寫入 memories 時使用的參數型別 */
@@ -1656,6 +1656,66 @@ export class Database {
       "SELECT COUNT(*) AS c FROM session_journal WHERE status = 'pending'",
     ).get() as { c: number }
     return row.c
+  }
+
+  getJournalEntry(id: number): JournalEntry | null {
+    const row = this.db.prepare(`
+      SELECT id, session_id, message_id, content, content_hash, score,
+             reasons_json, status, expires_at, promoted_memory_id,
+             project_id, created_at
+      FROM session_journal WHERE id = ?
+    `).get(id) as {
+      id: number
+      session_id: string | null
+      message_id: string | null
+      content: string
+      content_hash: string
+      score: number
+      reasons_json: string | null
+      status: string
+      expires_at: string | null
+      promoted_memory_id: number | null
+      project_id: string | null
+      created_at: string
+    } | undefined
+    if (!row) return null
+    return {
+      id: row.id,
+      sessionId: row.session_id,
+      messageId: row.message_id,
+      content: row.content,
+      contentHash: row.content_hash,
+      score: row.score,
+      reasonsJson: row.reasons_json,
+      status: row.status as JournalStatus,
+      expiresAt: row.expires_at,
+      promotedMemoryId: row.promoted_memory_id,
+      projectId: row.project_id,
+      createdAt: row.created_at,
+    }
+  }
+
+  /** 升級 journal entry 為 promoted; caller 已透過 saveMemory 寫入 memories table
+   *  並拿到 memoryId,本方法只更新 journal 的 status + 回填 promoted_memory_id。
+   *  回 false 表示 entry 不存在或已不在 'pending' 狀態 (idempotent)。 */
+  promoteJournalEntry(id: number, memoryId: number): boolean {
+    const info = this.db.prepare(`
+      UPDATE session_journal
+      SET status = 'promoted', promoted_memory_id = ?
+      WHERE id = ? AND status = 'pending'
+    `).run(memoryId, id)
+    return info.changes > 0
+  }
+
+  /** 標記 entry 為 rejected, expires_at 設為 now+7d (decay sweep 才真的刪除)。
+   *  caller 傳 expiresAt ISO string; 回 false 表示 entry 不存在或非 pending。 */
+  rejectJournalEntry(id: number, expiresAt: string): boolean {
+    const info = this.db.prepare(`
+      UPDATE session_journal
+      SET status = 'rejected', expires_at = ?
+      WHERE id = ? AND status = 'pending'
+    `).run(expiresAt, id)
+    return info.changes > 0
   }
 
   queryMemories(query: string, limit: number, projectId?: string | null): Memory[] {

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -1718,6 +1718,31 @@ export class Database {
     return info.changes > 0
   }
 
+  /** Decay sweep (P1 step 7):
+   *   - rejected entries past expires_at → DELETE
+   *   - pending entries older than 30 days → DELETE
+   *  promoted entries 留著作 audit trail (有 promoted_memory_id 指 memories.id)。
+   *  manual memories 在 memories table,本方法完全不碰。 */
+  sweepJournal(now: Date = new Date()): { rejectedDeleted: number; pendingDeleted: number } {
+    const nowIso = now.toISOString()
+    const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString()
+
+    const rejectedInfo = this.db.prepare(`
+      DELETE FROM session_journal
+      WHERE status = 'rejected' AND expires_at IS NOT NULL AND expires_at < ?
+    `).run(nowIso)
+
+    const pendingInfo = this.db.prepare(`
+      DELETE FROM session_journal
+      WHERE status = 'pending' AND created_at < ?
+    `).run(thirtyDaysAgo)
+
+    return {
+      rejectedDeleted: rejectedInfo.changes,
+      pendingDeleted: pendingInfo.changes,
+    }
+  }
+
   queryMemories(query: string, limit: number, projectId?: string | null): Memory[] {
     const rawQuery = query
     const q = Database.fts5QuoteIfNeeded(query)

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import BetterSqlite3 from 'better-sqlite3'
+import { createHash } from 'node:crypto'
 import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
 import path from 'node:path'
-import type { Project, SessionMeta, SearchOptions, SessionSearchPage, SessionFile, FileOperation, OutcomeStatus, FileHistoryEntry, SubagentSession, SessionFileInput, Memory, MemoryType, Topic, SessionCheckpoint } from './types.js'
+import type { Project, SessionMeta, SearchOptions, SessionSearchPage, SessionFile, FileOperation, OutcomeStatus, FileHistoryEntry, SubagentSession, SessionFileInput, Memory, MemoryType, Topic, SessionCheckpoint, JournalEntryInput } from './types.js'
 import { scrubErrorMessage } from './log-safe.js'
 
 /** 寫入 memories 時使用的參數型別 */
@@ -733,6 +734,47 @@ const migrations: Migration[] = [
       const cols = db.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>
       if (cols.some(c => c.name === 'harvest_text')) return
       db.exec('ALTER TABLE sessions ADD COLUMN harvest_text TEXT;')
+    },
+  },
+  {
+    version: 22,
+    description: 'add session_journal table for low-trust harvest candidates (issue #21 P1)',
+    up: (db) => {
+      const exists = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='session_journal'",
+      ).get()
+      if (exists) return
+
+      // Pre-check: memories table 必須存在 (v16 建立)。runMigrations 應已順序跑完
+      // 前面的 migration; 若不在則 schema 損壞,abort 比 silently 建立 dangling FK 安全。
+      const memoriesExists = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='memories'",
+      ).get()
+      if (!memoriesExists) {
+        throw new Error(
+          'v22 migration requires memories table (created in v16). ' +
+          'Schema appears corrupt — restore from pre-v22 backup.',
+        )
+      }
+
+      db.exec(`
+        CREATE TABLE session_journal (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          session_id TEXT,
+          message_id TEXT,
+          content TEXT NOT NULL,
+          content_hash TEXT NOT NULL,
+          score INTEGER NOT NULL,
+          reasons_json TEXT,
+          status TEXT NOT NULL DEFAULT 'pending',
+          expires_at TEXT,
+          promoted_memory_id INTEGER REFERENCES memories(id),
+          project_id TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE INDEX idx_journal_status ON session_journal(status, expires_at);
+        CREATE UNIQUE INDEX idx_journal_hash ON session_journal(content_hash);
+      `)
     },
   },
 ]
@@ -1573,6 +1615,42 @@ export class Database {
       projectId,
     )
     return Number(info.lastInsertRowid)
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // session_journal DAO (issue #21 P1)
+  // 低信任 harvest 候選的寫入入口; manual recall_save 仍走 saveMemory()。
+  // ─────────────────────────────────────────────────────────────
+
+  /** 寫入 journal 條目。content_hash 內部以 SHA-256 計算; 同 hash 第二次 INSERT
+   *  會被 UNIQUE INDEX 擋下並回傳 0 (idempotency)。
+   *
+   *  注意: better-sqlite3 的 INSERT OR IGNORE 在 IGNORE'd 時, lastInsertRowid
+   *  不會歸零 (保留前次成功 insert 的 rowid)。所以用 info.changes 判 dedup。 */
+  saveJournalEntry(input: JournalEntryInput): number {
+    const hash = createHash('sha256').update(input.content).digest('hex')
+    const info = this.db.prepare(`
+      INSERT OR IGNORE INTO session_journal
+        (session_id, message_id, content, content_hash, score, reasons_json, project_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      input.sessionId ?? null,
+      input.messageId ?? null,
+      input.content,
+      hash,
+      input.score,
+      input.reasonsJson ?? null,
+      input.projectId ?? null,
+    )
+    return info.changes === 0 ? 0 : Number(info.lastInsertRowid)
+  }
+
+  /** 給 /health endpoint 用; promotion path manual-only,user 看 pending 數決定是否 invoke。 */
+  getJournalPendingCount(): number {
+    const row = this.db.prepare(
+      "SELECT COUNT(*) AS c FROM session_journal WHERE status = 'pending'",
+    ).get() as { c: number }
+    return row.c
   }
 
   queryMemories(query: string, limit: number, projectId?: string | null): Memory[] {

--- a/src/core/maintenance-coordinator.ts
+++ b/src/core/maintenance-coordinator.ts
@@ -28,6 +28,7 @@ export interface MaintenanceOptions {
 }
 
 export class MaintenanceCoordinator {
+  private readonly db: Database
   private readonly compression: CompressionPipeline
   private readonly intervalMs: number
   private readonly batchSize: number
@@ -39,6 +40,7 @@ export class MaintenanceCoordinator {
     svc: MemoryService,
     opts: MaintenanceOptions = {},
   ) {
+    this.db = db
     this.compression = new CompressionPipeline(db, svc)
     this.intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS
     this.batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE
@@ -63,16 +65,34 @@ export class MaintenanceCoordinator {
     }
   }
 
-  /** Run one compression pass. Returns null if a prior tick is still in flight
-   *  (single-flight drop). The await before the synchronous runOnce() is load-
-   *  bearing: it yields the microtask queue so concurrent callers observe the
-   *  inflight flag before this body starts its DB work. */
+  /** Run one compression pass + journal sweep. Returns compression stats; sweep
+   *  results are logged (not in the return type, to keep callers backward-
+   *  compatible). Null if a prior tick is still in flight (single-flight drop).
+   *
+   *  The await before the synchronous runOnce() is load-bearing: it yields the
+   *  microtask queue so concurrent callers observe the inflight flag before this
+   *  body starts its DB work.
+   *
+   *  Journal sweep (#21 P1 step 7): rejected past expires_at + pending older
+   *  than 30 days are deleted. Sweep error is caught and logged separately so
+   *  it does not mask a successful compression pass. */
   async tick(): Promise<CompressionStats | null> {
     if (this.inflight) return null
     this.inflight = true
     try {
       await Promise.resolve()
-      return this.compression.runOnce({ batchSize: this.batchSize })
+      const stats = this.compression.runOnce({ batchSize: this.batchSize })
+      try {
+        const sweep = this.db.sweepJournal()
+        if (sweep.rejectedDeleted > 0 || sweep.pendingDeleted > 0) {
+          console.log(
+            `[maintenance] journal sweep: rejected=${sweep.rejectedDeleted} pending=${sweep.pendingDeleted}`,
+          )
+        }
+      } catch (err) {
+        console.warn('[maintenance] journal sweep error:', scrubErrorMessage(err))
+      }
+      return stats
     } catch (err) {
       // DB errors can carry memory content in .message; scrub before logging.
       console.warn('[maintenance] tick error:', scrubErrorMessage(err))

--- a/src/core/outcome-extractor.ts
+++ b/src/core/outcome-extractor.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { ParsedLine } from './types.js'
-import { scoreKnowledgeBearing, KNOWLEDGE_THRESHOLD, isProcessReport } from './outcome-scorer.js'
+import { scoreKnowledgeBearing, isProcessReport } from './outcome-scorer.js'
 
 // 從 session 挑「last substantial assistant text」作為記憶候選,餵 outcome-scorer.ts 評分。
 // 與 summarizer.ts inferOutcome 區別:inferOutcome 推 OutcomeStatus(committed/tested/...),
@@ -36,10 +36,12 @@ function pickLastSubstantialAssistant(messages: ParsedLine[]): string | null {
 }
 
 // length / markdown 結構是廉價 fast-path;短而高 signal 的純文字結語(例「Root cause:
-// x.ts:42。495/495 tests pass.」)走 scorer 兜底——避免 length gate 在 scorer 之前就濾掉
-// plan 想抓的真實 outcome。summarizer 仍會再跑 scorer 確認 score>=threshold 才 persist。
+// x.ts:42。495/495 tests pass.」、「我們決定改用 SQLite」)走 scorer 兜底。
+// v0.3.0 (#21 P1): 門檻從 score >= 2 降為 score >= 1。理由——P1 移除 persistence
+// gate 後, score 0/1 也應進 journal 留作 candidate, walk-back 上游不該預先濾掉。
+// score=0 (含 noise / process-report 短路) 仍擋, 不會引入空字串/純 ack 雜訊。
 function isSubstantial(text: string): boolean {
   if (text.length >= SUBSTANTIAL_MIN_CHARS) return true
   if (STRUCTURAL_RES.some(p => p.test(text))) return true
-  return scoreKnowledgeBearing(text).score >= KNOWLEDGE_THRESHOLD
+  return scoreKnowledgeBearing(text).score >= 1
 }

--- a/src/core/summarizer.ts
+++ b/src/core/summarizer.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { ParsedLine, SessionSummary, OutcomeSignals, OutcomeStatus, FileOperation, SessionFileInput } from './types.js'
 import { extractOutcome } from './outcome-extractor.js'
-import { scoreKnowledgeBearing, KNOWLEDGE_THRESHOLD } from './outcome-scorer.js'
+import { scoreKnowledgeBearing } from './outcome-scorer.js'
 
 /** 摘要引擎版本（每次規則改動時遞增，讓 backfill 可追蹤） */
 export const SUMMARY_VERSION = 2
@@ -432,12 +432,16 @@ export function summarizeSession(
   // ── Outcome ──
   const { status: outcomeStatus, signals: outcomeSignals } = inferOutcome(messages)
 
-  // ── Harvest candidate (issue #18: last substantial assistant, scored knowledge-bearing) ──
+  // ── Harvest candidate (issue #18 outcome cluster + #21 P1 journal split) ──
+  // v0.3.0: 移除 score >= 2 persistence gate (P1 設計: harvest broadly, remember
+  // narrowly)。但保留 hard floor: noise / process-report 仍 short-circuit (前者
+  // 是純 ack token、後者是 session 收尾報告; 都不該進 journal)。
   const extraction = extractOutcome(messages)
   let harvestText: string | null = null
   if (extraction.candidateText) {
     const result = scoreKnowledgeBearing(extraction.candidateText)
-    if (result.score >= KNOWLEDGE_THRESHOLD) {
+    const isHardFloor = result.reasons.includes('noise') || result.reasons.includes('process-report')
+    if (!isHardFloor) {
       harvestText = truncate(extraction.candidateText, MAX_HARVEST_LEN)
     }
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -220,6 +220,37 @@ export interface Memory {
   createdAt: string
 }
 
+// ── ccRecall 新增：session_journal（issue #21 P1：low-trust harvest 候選） ──
+
+/** journal 條目狀態：pending=harvester 寫入起點；promoted=已 manual promote 到 memories；rejected=待 decay sweep 清除 */
+export type JournalStatus = 'pending' | 'promoted' | 'rejected'
+
+/** session_journal 條目（DB row） */
+export interface JournalEntry {
+  id: number
+  sessionId: string | null
+  messageId: string | null
+  content: string
+  contentHash: string
+  score: number
+  reasonsJson: string | null
+  status: JournalStatus
+  expiresAt: string | null
+  promotedMemoryId: number | null
+  projectId: string | null
+  createdAt: string
+}
+
+/** 寫入 session_journal 的參數型別 */
+export interface JournalEntryInput {
+  sessionId?: string | null
+  messageId?: string | null
+  content: string
+  score: number
+  reasonsJson?: string | null
+  projectId?: string | null
+}
+
 // ── ccRecall 新增：元認知型別（Phase 3） ──
 
 /** 知識深度（由 mention_count 衍生：>=5 deep, >=2 medium, >=1 shallow, else none） */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -251,6 +251,18 @@ export interface JournalEntryInput {
   projectId?: string | null
 }
 
+/** Pending journal listing 用 — 截 200 字 preview, 不含 contentHash / status / expiresAt
+ *  / promotedMemoryId（status 已固定 'pending', 其餘欄位對 list view 無用）。 */
+export interface JournalEntryPreview {
+  id: number
+  sessionId: string | null
+  score: number
+  reasonsJson: string | null
+  contentPreview: string
+  projectId: string | null
+  createdAt: string
+}
+
 // ── ccRecall 新增：元認知型別（Phase 3） ──
 
 /** 知識深度（由 mention_count 衍生：>=5 deep, >=2 medium, >=1 shallow, else none） */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -343,6 +343,9 @@ export interface HealthResult {
   sessionCount: number
   memoryCount: number
   topicCount: number
+  /** session_journal pending count — surfaces auto-harvested low-trust candidates
+   *  so user knows when to invoke `ccmem promote`. (issue #21 P1) */
+  journalPendingCount: number
   uptime: number
   /** ISO timestamp of last PRAGMA integrity_check tick, or null if the monitor
    *  has not completed its first run yet (or is not attached — tests use

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { JsonlWatcher } from './core/watcher.js'
 import { installDaemon, uninstallDaemon } from './cli/daemon.js'
 import { installHooks, uninstallHooks } from './cli/hooks-installer.js'
 import { runCleanupCli } from './cli/cleanup.js'
+import { runPromote, runReject, parsePromoteFlags } from './cli/journal.js'
 
 /** Read the package.json version shipped next to this bundle. Works across
  *  layouts: src/index.ts (tsx) → ../package.json, dist/index.js → ../package.json,
@@ -68,6 +69,17 @@ if (subcommand === 'install-daemon' || subcommand === 'uninstall-daemon') {
     console.error(`[ccmem cleanup] ${err.message}`)
     process.exit(1)
   })
+} else if (subcommand === 'promote') {
+  const { idStr, opts } = parsePromoteFlags(process.argv.slice(3))
+  runPromote(idStr, opts).then(code => process.exit(code)).catch((err: Error) => {
+    console.error(`[ccmem promote] ${err.message}`)
+    process.exit(1)
+  })
+} else if (subcommand === 'reject') {
+  runReject(process.argv[3]).then(code => process.exit(code)).catch((err: Error) => {
+    console.error(`[ccmem reject] ${err.message}`)
+    process.exit(1)
+  })
 } else if (subcommand === '--help' || subcommand === '-h' || subcommand === 'help') {
   printHelp()
   process.exit(0)
@@ -96,6 +108,8 @@ Usage:
   ccmem cleanup --orphans          List orphan memories (read-only dry run)
   ccmem cleanup --orphans --yes    Delete orphan memories after stdin confirmation
   ccmem cleanup --orphans --reconcile   Run indexer first (writes; stop daemon first)
+  ccmem promote <id> [--type T] [--confidence C]   Promote a journal entry to memories
+  ccmem reject <id>                Mark a journal entry as rejected (decay sweep cleans up)
   ccmem --version                  Print the installed package version
 
 Environment:

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -65,7 +65,7 @@ describe('schema', () => {
     expect(idxNames).toContain('idx_message_uuids_session')
     expect(idxNames).toContain('idx_sessions_project')
     expect(idxNames).toContain('idx_journal_status')
-    expect(idxNames).toContain('idx_journal_hash')
+    expect(idxNames).toContain('idx_journal_session_hash')
     expect(idxNames).not.toContain('idx_messages_session')
   })
 })
@@ -87,14 +87,42 @@ describe('session_journal DAO (issue #21 P1)', () => {
     expect(db.getJournalPendingCount()).toBe(1)
   })
 
-  it('saveJournalEntry deduplicates by content_hash (UNIQUE INDEX idempotency)', () => {
-    const first = db.saveJournalEntry({ content: 'duplicate content', score: 0 })
+  it('saveJournalEntry deduplicates same content within same session (UNIQUE INDEX idempotency)', () => {
+    // UNIQUE 是 (session_id, content_hash); 同 session retry 仍 dedup
+    const first = db.saveJournalEntry({
+      sessionId: 'sess-A',
+      content: 'duplicate content',
+      score: 0,
+    })
     expect(first).toBeGreaterThan(0)
 
-    const second = db.saveJournalEntry({ content: 'duplicate content', score: 0 })
+    const second = db.saveJournalEntry({
+      sessionId: 'sess-A',
+      content: 'duplicate content',
+      score: 0,
+    })
     expect(second).toBe(0) // INSERT OR IGNORE → lastInsertRowid 0 表示被擋下
 
     expect(db.getJournalPendingCount()).toBe(1)
+  })
+
+  it('saveJournalEntry accepts same content from DIFFERENT sessions (cross-session leakage fix, Codex review)', () => {
+    // P1 fix-up: 兩個不同 session 產生同樣 outcome cluster 各自留一筆,
+    // 不再被 global content_hash 靜默吃掉 (Codex finding #1)。
+    const a = db.saveJournalEntry({
+      sessionId: 'sess-X',
+      content: 'Root cause: same wording, different session',
+      score: 2,
+    })
+    const b = db.saveJournalEntry({
+      sessionId: 'sess-Y',
+      content: 'Root cause: same wording, different session',
+      score: 2,
+    })
+    expect(a).toBeGreaterThan(0)
+    expect(b).toBeGreaterThan(0)
+    expect(b).not.toBe(a)
+    expect(db.getJournalPendingCount()).toBe(2)
   })
 
   it('saveJournalEntry stores score 0 entries (no threshold gate)', () => {

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -105,6 +105,44 @@ describe('session_journal DAO (issue #21 P1)', () => {
   })
 })
 
+describe('recall trust boundary (issue #21 P1)', () => {
+  // P1 invariant: unpromoted journal entries 是 low-trust,不該出現在 recall_query
+  // / recall_context 結果。queryMemories 只查 memories table; journal 沒有對應的
+  // FTS5 virtual table,自然不會被 FTS match。本 test 鎖住設計意圖,未來若改寫
+  // query 邏輯讓 journal 漏進來,test fail 等於告警。
+  it('queryMemories does NOT return unpromoted journal entries', () => {
+    db.saveJournalEntry({
+      content: 'unpromoted candidate text with token: needle-zxq-12345',
+      score: 0,
+    })
+    expect(db.getJournalPendingCount()).toBe(1)
+    expect(db.getMemoryCount()).toBe(0)
+
+    const results = db.queryMemories('needle-zxq-12345', 10)
+    expect(results).toHaveLength(0)
+  })
+
+  it('queryMemories returns memories but NOT journal even when both have matching content', () => {
+    // 同樣 content 同時寫進 journal + memories,query 只該回 memories 那筆。
+    const matchToken = 'distinctive-token-abc-789'
+    db.saveJournalEntry({
+      content: `journal version: ${matchToken}`,
+      score: 0,
+    })
+    const memId = db.saveMemory({
+      sessionId: null,
+      messageId: null,
+      content: `memory version: ${matchToken}`,
+      type: 'discovery',
+    })
+
+    const results = db.queryMemories(matchToken, 10)
+    expect(results).toHaveLength(1)
+    expect(results[0].id).toBe(memId)
+    expect(results[0].content).toContain('memory version')
+  })
+})
+
 describe('migration system', () => {
   it('schema_version table exists with baseline', () => {
     const rows = db.rawAll<{ version: number; description: string }>(

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -41,7 +41,7 @@ afterEach(async () => {
 })
 
 describe('schema', () => {
-  it('createSchema → tables + indexes at v20 target state', () => {
+  it('createSchema → tables + indexes at v22 target state', () => {
     const tables = db.rawAll<{ name: string }>(
       "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
     ).map(r => r.name)
@@ -52,6 +52,7 @@ describe('schema', () => {
     expect(tables).toContain('memories')
     expect(tables).toContain('memories_fts')
     expect(tables).toContain('sessions_fts')
+    expect(tables).toContain('session_journal')
     // v20 dropped
     expect(tables).not.toContain('messages')
     expect(tables).not.toContain('messages_fts')
@@ -63,7 +64,44 @@ describe('schema', () => {
     ).map(r => r.name)
     expect(idxNames).toContain('idx_message_uuids_session')
     expect(idxNames).toContain('idx_sessions_project')
+    expect(idxNames).toContain('idx_journal_status')
+    expect(idxNames).toContain('idx_journal_hash')
     expect(idxNames).not.toContain('idx_messages_session')
+  })
+})
+
+describe('session_journal DAO (issue #21 P1)', () => {
+  it('saveJournalEntry inserts row, getJournalPendingCount counts pending', () => {
+    expect(db.getJournalPendingCount()).toBe(0)
+
+    const id = db.saveJournalEntry({
+      sessionId: null,
+      messageId: null,
+      content: 'first outcome candidate',
+      score: 1,
+      reasonsJson: '["decision-language"]',
+      projectId: null,
+    })
+
+    expect(id).toBeGreaterThan(0)
+    expect(db.getJournalPendingCount()).toBe(1)
+  })
+
+  it('saveJournalEntry deduplicates by content_hash (UNIQUE INDEX idempotency)', () => {
+    const first = db.saveJournalEntry({ content: 'duplicate content', score: 0 })
+    expect(first).toBeGreaterThan(0)
+
+    const second = db.saveJournalEntry({ content: 'duplicate content', score: 0 })
+    expect(second).toBe(0) // INSERT OR IGNORE → lastInsertRowid 0 表示被擋下
+
+    expect(db.getJournalPendingCount()).toBe(1)
+  })
+
+  it('saveJournalEntry stores score 0 entries (no threshold gate)', () => {
+    // P1 核心: 移除 KNOWLEDGE_THRESHOLD ≥ 2 gate, score 0/1 也進 journal
+    const id = db.saveJournalEntry({ content: 'low-score outcome', score: 0 })
+    expect(id).toBeGreaterThan(0)
+    expect(db.getJournalPendingCount()).toBe(1)
   })
 })
 

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -103,6 +103,74 @@ describe('session_journal DAO (issue #21 P1)', () => {
     expect(id).toBeGreaterThan(0)
     expect(db.getJournalPendingCount()).toBe(1)
   })
+
+  it('sweepJournal deletes rejected entries past expires_at', () => {
+    const id = db.saveJournalEntry({ content: 'rejected-soon', score: 0 })
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+    db.rejectJournalEntry(id, yesterday)
+
+    const result = db.sweepJournal()
+    expect(result.rejectedDeleted).toBe(1)
+    expect(db.getJournalEntry(id)).toBeNull()
+  })
+
+  it('sweepJournal keeps rejected entries with future expires_at', () => {
+    const id = db.saveJournalEntry({ content: 'rejected-later', score: 0 })
+    const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+    db.rejectJournalEntry(id, future)
+
+    const result = db.sweepJournal()
+    expect(result.rejectedDeleted).toBe(0)
+    expect(db.getJournalEntry(id)?.status).toBe('rejected')
+  })
+
+  it('sweepJournal deletes pending entries older than 30 days', () => {
+    const id = db.saveJournalEntry({ content: 'old-pending', score: 0 })
+    // Backdate created_at by 31 days
+    db.rawExec(
+      `UPDATE session_journal SET created_at = datetime('now', '-31 days') WHERE id = ${id}`,
+    )
+
+    const result = db.sweepJournal()
+    expect(result.pendingDeleted).toBe(1)
+    expect(db.getJournalEntry(id)).toBeNull()
+  })
+
+  it('sweepJournal does NOT delete pending entries within 30 days', () => {
+    const id = db.saveJournalEntry({ content: 'fresh-pending', score: 0 })
+    const result = db.sweepJournal()
+    expect(result.pendingDeleted).toBe(0)
+    expect(db.getJournalEntry(id)?.status).toBe('pending')
+  })
+
+  it('sweepJournal does NOT touch promoted entries (audit trail)', () => {
+    const id = db.saveJournalEntry({ content: 'promoted-keep', score: 2 })
+    const memId = db.saveMemory({
+      sessionId: null, messageId: null, content: 'promoted-keep', type: 'discovery',
+    })
+    db.promoteJournalEntry(id, memId)
+
+    // Even backdating to ancient
+    db.rawExec(
+      `UPDATE session_journal SET created_at = datetime('now', '-90 days') WHERE id = ${id}`,
+    )
+    const result = db.sweepJournal()
+    expect(result.rejectedDeleted).toBe(0)
+    expect(result.pendingDeleted).toBe(0)
+    expect(db.getJournalEntry(id)?.status).toBe('promoted')
+  })
+
+  it('sweepJournal does NOT touch memories table (manual exemption)', () => {
+    const memId = db.saveMemory({
+      sessionId: null, messageId: null, content: 'manual save', type: 'decision',
+    })
+    db.rawExec(
+      `UPDATE memories SET created_at = datetime('now', '-90 days') WHERE id = ${memId}`,
+    )
+
+    db.sweepJournal()
+    expect(db.getMemoryCount()).toBe(1)
+  })
 })
 
 describe('recall trust boundary (issue #21 P1)', () => {

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -199,24 +199,26 @@ describe('E2E: index → search → HTTP', () => {
     expect(loginTopic).toBeTruthy()
   })
 
-  it('Phase 3c: POST /session/end harvest inherits session topics into memory_topics', async () => {
+  it('P1 (#21): POST /session/end writes session_journal, NOT memory_topics', async () => {
+    // v0.2.x 邏輯: session/end harvest 寫 memories + 繼承 session topics 到 memory_topics
+    // v0.3.0 (P1): hook auto-harvest 改寫 session_journal; memory_topics 留給 promote 路徑 (C4)
     const sessions = db.rawAll<{ id: string }>('SELECT id FROM sessions LIMIT 1')
     const sessionId = sessions[0].id
-    const sessionTopicsBefore = db.getSessionTopicKeys(sessionId)
-    expect(sessionTopicsBefore.length).toBeGreaterThan(0)
 
-    const { status, body } = await postJson(
+    const { status } = await postJson(
       `http://127.0.0.1:${port}/session/end`,
       { sessionId },
     )
     expect(status).toBe(200)
-    const savedIds = (body as { memoriesSaved: number[] }).memoriesSaved
-    expect(savedIds.length).toBe(1)
 
-    const memTopics = db.rawAll<{ topic_key: string }>(
-      `SELECT topic_key FROM memory_topics WHERE memory_id = ${savedIds[0]} ORDER BY topic_key`,
-    ).map(r => r.topic_key)
-    expect(memTopics).toEqual(sessionTopicsBefore)
+    // 核心 assertion: memory_topics 沒有任何 row (P1 不繼承)
+    const memTopicsAfter = db.rawAll<{ topic_key: string }>(
+      'SELECT topic_key FROM memory_topics',
+    )
+    expect(memTopicsAfter).toHaveLength(0)
+
+    // memories table 也不該被 hook 寫到 (manual recall_save 才會寫)
+    expect(db.getMemoryCount()).toBe(0)
   })
 
   it('Phase 4d: GET /lint/warnings returns orphan + stale report', async () => {

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -189,6 +189,13 @@ describe('E2E: index → search → HTTP', () => {
     expect((body as { memoryCount: number }).memoryCount).toBe(2)
   })
 
+  it('P1 (#21): GET /health reports journalPendingCount for promote-prompt surfacing', async () => {
+    db.saveJournalEntry({ content: 'pending-1', score: 0 })
+    db.saveJournalEntry({ content: 'pending-2', score: 1 })
+    const { body } = await fetch(`http://127.0.0.1:${port}/health`)
+    expect((body as { journalPendingCount: number }).journalPendingCount).toBe(2)
+  })
+
   it('Phase 3c: indexer populates knowledge_map from session topics', () => {
     const topics = db.rawAll<{ topic_key: string; mention_count: number }>(
       'SELECT topic_key, mention_count FROM knowledge_map ORDER BY topic_key',

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -7,51 +7,7 @@ import http from 'node:http'
 import { Database } from '../src/core/database'
 import { runIndexer } from '../src/core/indexer'
 import { createServer } from '../src/api/server'
-
-function fetch(url: string): Promise<{ status: number; body: unknown }> {
-  return new Promise((resolve, reject) => {
-    http.get(url, (res) => {
-      const chunks: Buffer[] = []
-      res.on('data', (chunk: Buffer) => chunks.push(chunk))
-      res.on('end', () => {
-        const body = JSON.parse(Buffer.concat(chunks).toString())
-        resolve({ status: res.statusCode!, body })
-      })
-      res.on('error', reject)
-    }).on('error', reject)
-  })
-}
-
-function postJson(
-  url: string,
-  payload: unknown,
-  extraHeaders: Record<string, string> = {},
-): Promise<{ status: number; body: unknown }> {
-  return new Promise((resolve, reject) => {
-    const u = new URL(url)
-    const data = JSON.stringify(payload)
-    const req = http.request({
-      hostname: u.hostname, port: u.port, path: u.pathname + u.search,
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(data),
-        ...extraHeaders,
-      },
-    }, (res) => {
-      const chunks: Buffer[] = []
-      res.on('data', (chunk: Buffer) => chunks.push(chunk))
-      res.on('end', () => {
-        const body = JSON.parse(Buffer.concat(chunks).toString())
-        resolve({ status: res.statusCode!, body })
-      })
-      res.on('error', reject)
-    })
-    req.on('error', reject)
-    req.write(data)
-    req.end()
-  })
-}
+import { postJson, fetchJson as fetch } from './fixtures/helpers.js'
 
 describe('E2E: index → search → HTTP', () => {
   let tmpDir: string

--- a/tests/hooks-session-end.test.ts
+++ b/tests/hooks-session-end.test.ts
@@ -22,7 +22,7 @@ function startMockServer(): Promise<{ server: http.Server; port: number; receive
         received.push({ path: req.url, method: req.method, body })
         res.statusCode = 200
         res.setHeader('Content-Type', 'application/json')
-        res.end(JSON.stringify({ ok: true, memoriesSaved: [1] }))
+        res.end(JSON.stringify({ ok: true, journalSaved: [1] }))
       })
     })
     server.listen(0, '127.0.0.1', () => {

--- a/tests/journal-promote.test.ts
+++ b/tests/journal-promote.test.ts
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import http from 'node:http'
+import { Database } from '../src/core/database.js'
+import { createServer } from '../src/api/server.js'
+
+function postJson(
+  url: string,
+  payload: unknown,
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url)
+    const data = JSON.stringify(payload)
+    const req = http.request({
+      hostname: u.hostname, port: u.port, path: u.pathname + u.search,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(data),
+      },
+    }, (res) => {
+      const chunks: Buffer[] = []
+      res.on('data', (chunk: Buffer) => chunks.push(chunk))
+      res.on('end', () => {
+        const body = JSON.parse(Buffer.concat(chunks).toString())
+        resolve({ status: res.statusCode!, body })
+      })
+      res.on('error', reject)
+    })
+    req.on('error', reject)
+    req.write(data)
+    req.end()
+  })
+}
+
+describe('POST /journal/promote (#21 P1 step 6)', () => {
+  let tmpDir: string
+  let db: Database
+  let server: http.Server
+  let port: number
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ccrecall-promote-'))
+    db = new Database(path.join(tmpDir, 'test.db'))
+    server = createServer(db)
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        port = (server.address() as { port: number }).port
+        resolve()
+      })
+    })
+  })
+
+  afterEach(async () => {
+    server.close()
+    db.close()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('promotes a pending journal entry to memories with default type/confidence', async () => {
+    const journalId = db.saveJournalEntry({
+      content: 'Root cause: token expiry. Fix verified.',
+      score: 3,
+      reasonsJson: '["decision-language","cause-effect","validation"]',
+    })
+    expect(db.getMemoryCount()).toBe(0)
+
+    const { status, body } = await postJson(
+      `http://127.0.0.1:${port}/journal/promote`,
+      { id: journalId },
+    )
+    expect(status).toBe(200)
+    const b = body as { ok: boolean; memoryId: number; journalId: number }
+    expect(b.ok).toBe(true)
+    expect(b.journalId).toBe(journalId)
+    expect(b.memoryId).toBeGreaterThan(0)
+
+    // Memories table now has the row
+    expect(db.getMemoryCount()).toBe(1)
+
+    // Journal status flipped
+    const after = db.getJournalEntry(journalId)
+    expect(after?.status).toBe('promoted')
+    expect(after?.promotedMemoryId).toBe(b.memoryId)
+  })
+
+  it('respects type / confidence overrides', async () => {
+    const journalId = db.saveJournalEntry({
+      content: 'A decision the user wants tagged explicitly.',
+      score: 2,
+    })
+    const { status } = await postJson(
+      `http://127.0.0.1:${port}/journal/promote`,
+      { id: journalId, type: 'decision', confidence: 0.9 },
+    )
+    expect(status).toBe(200)
+
+    const memories = db.queryMemories('decision the user', 10)
+    expect(memories).toHaveLength(1)
+    expect(memories[0].type).toBe('decision')
+    expect(memories[0].confidence).toBe(0.9)
+  })
+
+  it('returns 404 for non-existent id', async () => {
+    const { status, body } = await postJson(
+      `http://127.0.0.1:${port}/journal/promote`,
+      { id: 99999 },
+    )
+    expect(status).toBe(404)
+    expect((body as { error: string }).error).toMatch(/not found/)
+  })
+
+  it('returns 409 when entry is already promoted (idempotency boundary)', async () => {
+    const journalId = db.saveJournalEntry({ content: 'one-shot promote', score: 2 })
+    const first = await postJson(
+      `http://127.0.0.1:${port}/journal/promote`,
+      { id: journalId },
+    )
+    expect(first.status).toBe(200)
+
+    const second = await postJson(
+      `http://127.0.0.1:${port}/journal/promote`,
+      { id: journalId },
+    )
+    expect(second.status).toBe(409)
+    expect((second.body as { error: string }).error).toMatch(/promoted/)
+  })
+
+  it('rejects invalid id with 400', async () => {
+    const { status } = await postJson(
+      `http://127.0.0.1:${port}/journal/promote`,
+      { id: -1 },
+    )
+    expect(status).toBe(400)
+  })
+
+  it('rejects invalid confidence with 400', async () => {
+    const journalId = db.saveJournalEntry({ content: 'bad confidence', score: 0 })
+    const { status } = await postJson(
+      `http://127.0.0.1:${port}/journal/promote`,
+      { id: journalId, confidence: 1.5 },
+    )
+    expect(status).toBe(400)
+  })
+})
+
+describe('POST /journal/reject (#21 P1 step 6)', () => {
+  let tmpDir: string
+  let db: Database
+  let server: http.Server
+  let port: number
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ccrecall-reject-'))
+    db = new Database(path.join(tmpDir, 'test.db'))
+    server = createServer(db)
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        port = (server.address() as { port: number }).port
+        resolve()
+      })
+    })
+  })
+
+  afterEach(async () => {
+    server.close()
+    db.close()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('flips status to rejected and sets expires_at ~7 days out', async () => {
+    const journalId = db.saveJournalEntry({ content: 'noise candidate', score: 0 })
+
+    const before = Date.now()
+    const { status, body } = await postJson(
+      `http://127.0.0.1:${port}/journal/reject`,
+      { id: journalId },
+    )
+    expect(status).toBe(200)
+    const b = body as { ok: boolean; journalId: number; expiresAt: string }
+    expect(b.ok).toBe(true)
+    expect(b.journalId).toBe(journalId)
+
+    const expiresMs = Date.parse(b.expiresAt)
+    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000
+    expect(expiresMs).toBeGreaterThanOrEqual(before + sevenDaysMs - 1000)
+    expect(expiresMs).toBeLessThanOrEqual(Date.now() + sevenDaysMs + 1000)
+
+    const after = db.getJournalEntry(journalId)
+    expect(after?.status).toBe('rejected')
+    expect(after?.expiresAt).toBe(b.expiresAt)
+  })
+
+  it('does not affect memories table', async () => {
+    const journalId = db.saveJournalEntry({ content: 'reject-only', score: 0 })
+    await postJson(`http://127.0.0.1:${port}/journal/reject`, { id: journalId })
+    expect(db.getMemoryCount()).toBe(0)
+  })
+
+  it('returns 404 for already-rejected entries', async () => {
+    const journalId = db.saveJournalEntry({ content: 'double reject', score: 0 })
+    await postJson(`http://127.0.0.1:${port}/journal/reject`, { id: journalId })
+    const second = await postJson(
+      `http://127.0.0.1:${port}/journal/reject`,
+      { id: journalId },
+    )
+    expect(second.status).toBe(404)
+  })
+})

--- a/tests/journal-promote.test.ts
+++ b/tests/journal-promote.test.ts
@@ -6,35 +6,7 @@ import os from 'node:os'
 import http from 'node:http'
 import { Database } from '../src/core/database.js'
 import { createServer } from '../src/api/server.js'
-
-function postJson(
-  url: string,
-  payload: unknown,
-): Promise<{ status: number; body: unknown }> {
-  return new Promise((resolve, reject) => {
-    const u = new URL(url)
-    const data = JSON.stringify(payload)
-    const req = http.request({
-      hostname: u.hostname, port: u.port, path: u.pathname + u.search,
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(data),
-      },
-    }, (res) => {
-      const chunks: Buffer[] = []
-      res.on('data', (chunk: Buffer) => chunks.push(chunk))
-      res.on('end', () => {
-        const body = JSON.parse(Buffer.concat(chunks).toString())
-        resolve({ status: res.statusCode!, body })
-      })
-      res.on('error', reject)
-    })
-    req.on('error', reject)
-    req.write(data)
-    req.end()
-  })
-}
+import { postJson, fetchJson } from './fixtures/helpers.js'
 
 describe('POST /journal/promote (#21 P1 step 6)', () => {
   let tmpDir: string
@@ -184,17 +156,7 @@ describe('GET /journal/pending (Codex review fix-up)', () => {
       score: 1,
     })
 
-    const resp = await new Promise<{ status: number; body: unknown }>((resolve, reject) => {
-      http.get(`http://127.0.0.1:${port}/journal/pending`, (res) => {
-        const chunks: Buffer[] = []
-        res.on('data', (c: Buffer) => chunks.push(c))
-        res.on('end', () => {
-          const body = JSON.parse(Buffer.concat(chunks).toString())
-          resolve({ status: res.statusCode!, body })
-        })
-        res.on('error', reject)
-      }).on('error', reject)
-    })
+    const resp = await fetchJson(`http://127.0.0.1:${port}/journal/pending`)
 
     expect(resp.status).toBe(200)
     const b = resp.body as {
@@ -214,17 +176,7 @@ describe('GET /journal/pending (Codex review fix-up)', () => {
         score: 0,
       })
     }
-    const resp = await new Promise<{ status: number; body: unknown }>((resolve, reject) => {
-      http.get(`http://127.0.0.1:${port}/journal/pending?limit=3`, (res) => {
-        const chunks: Buffer[] = []
-        res.on('data', (c: Buffer) => chunks.push(c))
-        res.on('end', () => {
-          const body = JSON.parse(Buffer.concat(chunks).toString())
-          resolve({ status: res.statusCode!, body })
-        })
-        res.on('error', reject)
-      }).on('error', reject)
-    })
+    const resp = await fetchJson(`http://127.0.0.1:${port}/journal/pending?limit=3`)
 
     expect(resp.status).toBe(200)
     expect((resp.body as { total: number }).total).toBe(3)
@@ -242,16 +194,7 @@ describe('GET /journal/pending (Codex review fix-up)', () => {
 
     db.saveJournalEntry({ sessionId: 'sess-keep', content: 'still pending', score: 1 })
 
-    const resp = await new Promise<{ body: unknown }>((resolve, reject) => {
-      http.get(`http://127.0.0.1:${port}/journal/pending`, (res) => {
-        const chunks: Buffer[] = []
-        res.on('data', (c: Buffer) => chunks.push(c))
-        res.on('end', () => {
-          resolve({ body: JSON.parse(Buffer.concat(chunks).toString()) })
-        })
-        res.on('error', reject)
-      }).on('error', reject)
-    })
+    const resp = await fetchJson(`http://127.0.0.1:${port}/journal/pending`)
 
     const entries = (resp.body as { entries: Array<{ contentPreview: string }> }).entries
     expect(entries).toHaveLength(1)

--- a/tests/journal-promote.test.ts
+++ b/tests/journal-promote.test.ts
@@ -147,6 +147,118 @@ describe('POST /journal/promote (#21 P1 step 6)', () => {
   })
 })
 
+describe('GET /journal/pending (Codex review fix-up)', () => {
+  let tmpDir: string
+  let db: Database
+  let server: http.Server
+  let port: number
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ccrecall-listpending-'))
+    db = new Database(path.join(tmpDir, 'test.db'))
+    server = createServer(db)
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        port = (server.address() as { port: number }).port
+        resolve()
+      })
+    })
+  })
+
+  afterEach(async () => {
+    server.close()
+    db.close()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns pending entries with id, score, reasons, content preview', async () => {
+    db.saveJournalEntry({
+      sessionId: 'sess-1',
+      content: 'first candidate with substantive content',
+      score: 2,
+      reasonsJson: '["decision-language","impl-facts"]',
+    })
+    db.saveJournalEntry({
+      sessionId: 'sess-2',
+      content: 'second',
+      score: 1,
+    })
+
+    const resp = await new Promise<{ status: number; body: unknown }>((resolve, reject) => {
+      http.get(`http://127.0.0.1:${port}/journal/pending`, (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (c: Buffer) => chunks.push(c))
+        res.on('end', () => {
+          const body = JSON.parse(Buffer.concat(chunks).toString())
+          resolve({ status: res.statusCode!, body })
+        })
+        res.on('error', reject)
+      }).on('error', reject)
+    })
+
+    expect(resp.status).toBe(200)
+    const b = resp.body as {
+      entries: Array<{ id: number; score: number; reasonsJson: string | null; contentPreview: string }>
+      total: number
+    }
+    expect(b.total).toBe(2)
+    expect(b.entries).toHaveLength(2)
+    expect(b.entries[0].contentPreview.length).toBeLessThanOrEqual(200)
+  })
+
+  it('honors limit param (capped at 100)', async () => {
+    for (let i = 0; i < 5; i++) {
+      db.saveJournalEntry({
+        sessionId: `sess-${i}`,
+        content: `candidate ${i}`,
+        score: 0,
+      })
+    }
+    const resp = await new Promise<{ status: number; body: unknown }>((resolve, reject) => {
+      http.get(`http://127.0.0.1:${port}/journal/pending?limit=3`, (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (c: Buffer) => chunks.push(c))
+        res.on('end', () => {
+          const body = JSON.parse(Buffer.concat(chunks).toString())
+          resolve({ status: res.statusCode!, body })
+        })
+        res.on('error', reject)
+      }).on('error', reject)
+    })
+
+    expect(resp.status).toBe(200)
+    expect((resp.body as { total: number }).total).toBe(3)
+  })
+
+  it('does NOT include promoted or rejected entries', async () => {
+    const id = db.saveJournalEntry({ sessionId: 'sess-prom', content: 'promote me', score: 2 })
+    const memId = db.saveMemory({
+      sessionId: null, messageId: null, content: 'promote me', type: 'discovery',
+    })
+    db.promoteJournalEntry(id, memId)
+
+    const id2 = db.saveJournalEntry({ sessionId: 'sess-rej', content: 'reject me', score: 0 })
+    db.rejectJournalEntry(id2, new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString())
+
+    db.saveJournalEntry({ sessionId: 'sess-keep', content: 'still pending', score: 1 })
+
+    const resp = await new Promise<{ body: unknown }>((resolve, reject) => {
+      http.get(`http://127.0.0.1:${port}/journal/pending`, (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (c: Buffer) => chunks.push(c))
+        res.on('end', () => {
+          resolve({ body: JSON.parse(Buffer.concat(chunks).toString()) })
+        })
+        res.on('error', reject)
+      }).on('error', reject)
+    })
+
+    const entries = (resp.body as { entries: Array<{ contentPreview: string }> }).entries
+    expect(entries).toHaveLength(1)
+    expect(entries[0].contentPreview).toContain('still pending')
+  })
+})
+
 describe('POST /journal/reject (#21 P1 step 6)', () => {
   let tmpDir: string
   let db: Database

--- a/tests/outcome-extractor.test.ts
+++ b/tests/outcome-extractor.test.ts
@@ -95,9 +95,18 @@ describe('extractOutcome — candidateText', () => {
     expect(extractOutcome(msgs).candidateText).toBe(text)
   })
 
-  it('still drops short text that scorer rejects (single weak signal)', () => {
-    // Single category match (decision-language only) — under threshold, no rescue.
+  it('v0.3.0 (#21 P1): short text with single weak signal IS accepted (was dropped pre-0.3.0)', () => {
+    // Pre-0.3.0: isSubstantial used score >= KNOWLEDGE_THRESHOLD (=2), so single
+    // category match was dropped. P1 lowered to score >= 1 so journal can capture
+    // short low-confidence candidates; persistence gate moved to promotion path.
     const text = '我們決定先吃飯'
+    const msgs = [makeMsg({ role: 'assistant', contentText: text })]
+    expect(extractOutcome(msgs).candidateText).toBe(text)
+  })
+
+  it('still drops short text with score=0 (hard floor: noise / no signal)', () => {
+    // Even after lowering threshold to >= 1, score=0 (no category match) is dropped.
+    const text = 'unclear without more info'
     const msgs = [makeMsg({ role: 'assistant', contentText: text })]
     expect(extractOutcome(msgs).candidateText).toBeNull()
   })

--- a/tests/session-end.test.ts
+++ b/tests/session-end.test.ts
@@ -54,12 +54,15 @@ const outcomeSession = [
   { type: 'assistant', uuid: 'o4', timestamp: '2026-04-15T10:03:00Z', message: { role: 'assistant', content: '## Auth fix shipped\n\nRoot cause: token expiry was not propagated to the refresh handler in /src/auth.ts:42. After first session expiry the silent fail looked like a stale UI bug.\n\nFix verified: 495/495 tests pass.' } },
 ]
 
-// Sub-threshold fixture: short Q&A, no structural markers, no high-signal
-// patterns, no git commit. Indexer must still write the session row, but
-// buildMemoryFromSession must skip the memory.
+// Sub-threshold fixture: short Q&A, no category match (score=0). v0.3.0 P1
+// lowered isSubstantial to score >= 1, so we use a phrase that doesn't trigger
+// any of the 5 category regexes (decision/impl-facts/constraints/cause-effect/
+// validation). "unclear without more info" matches none. Pre-0.3.0 fixture
+// "I cannot tell time directly." actually matches `cannot` (constraints) → score 1
+// — would now write to journal under P1 design.
 const subThresholdSession = [
-  { type: 'user', uuid: 's1', timestamp: '2026-04-15T11:00:00Z', message: { role: 'user', content: 'What time is it' } },
-  { type: 'assistant', uuid: 's2', timestamp: '2026-04-15T11:00:30Z', message: { role: 'assistant', content: 'I cannot tell time directly.' } },
+  { type: 'user', uuid: 's1', timestamp: '2026-04-15T11:00:00Z', message: { role: 'user', content: 'Anything?' } },
+  { type: 'assistant', uuid: 's2', timestamp: '2026-04-15T11:00:30Z', message: { role: 'assistant', content: 'unclear without more info' } },
 ]
 
 describe('POST /session/end — outcome-bearing session', () => {

--- a/tests/session-end.test.ts
+++ b/tests/session-end.test.ts
@@ -12,37 +12,7 @@ import {
   buildJournalCandidate,
 } from '../src/api/routes.js'
 import type { SessionMeta } from '../src/core/types.js'
-
-function postJson(
-  url: string,
-  payload: unknown,
-  extraHeaders: Record<string, string> = {},
-): Promise<{ status: number; body: unknown }> {
-  return new Promise((resolve, reject) => {
-    const u = new URL(url)
-    const data = JSON.stringify(payload)
-    const req = http.request({
-      hostname: u.hostname, port: u.port, path: u.pathname + u.search,
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(data),
-        ...extraHeaders,
-      },
-    }, (res) => {
-      const chunks: Buffer[] = []
-      res.on('data', (chunk: Buffer) => chunks.push(chunk))
-      res.on('end', () => {
-        const body = JSON.parse(Buffer.concat(chunks).toString())
-        resolve({ status: res.statusCode!, body })
-      })
-      res.on('error', reject)
-    })
-    req.on('error', reject)
-    req.write(data)
-    req.end()
-  })
-}
+import { postJson } from './fixtures/helpers.js'
 
 // Outcome-bearing fixture (issue #18 step 3): user prompt → tool work → git
 // commit invocation → last substantial assistant message with cause-effect

--- a/tests/session-end.test.ts
+++ b/tests/session-end.test.ts
@@ -9,9 +9,9 @@ import { runIndexer } from '../src/core/indexer.js'
 import { createServer } from '../src/api/server.js'
 import {
   inferConfidence,
-  buildMemoryFromSession,
+  buildJournalCandidate,
 } from '../src/api/routes.js'
-import type { OutcomeStatus, SessionMeta } from '../src/core/types.js'
+import type { SessionMeta } from '../src/core/types.js'
 
 function postJson(
   url: string,
@@ -127,37 +127,40 @@ describe('POST /session/end — outcome-bearing session', () => {
     expect((body as { error: string }).error).toMatch(/not found/)
   })
 
-  it('saves a memory whose content is the outcome cluster (NOT the user prompt)', async () => {
+  it('saves a journal entry whose content is the outcome cluster (NOT the user prompt)', async () => {
     const { status, body } = await postJson(`http://127.0.0.1:${port}/session/end`, {
       sessionId,
     })
     expect(status).toBe(200)
-    const b = body as { ok: boolean; memoriesSaved: number[]; dryRun: boolean }
+    const b = body as { ok: boolean; journalSaved: number[]; dryRun: boolean }
     expect(b.ok).toBe(true)
-    expect(b.memoriesSaved).toHaveLength(1)
+    expect(b.journalSaved).toHaveLength(1)
     expect(b.dryRun).toBe(false)
 
-    const saved = db.queryMemories('Auth fix shipped', 10)
-    expect(saved.length).toBeGreaterThan(0)
-    expect(saved[0].sessionId).toBe(sessionId)
-    expect(saved[0].content).toContain('Root cause')
-    expect(saved[0].content).not.toContain('[intent]')
-    expect(saved[0].content).not.toContain('Fix the login bug in auth.ts')
-    expect(saved[0].type).toBe('query')
+    // P1 (#21): hook auto-harvest 不再寫 memories table
+    expect(db.getMemoryCount()).toBe(0)
+
+    const journalRows = db.rawAll<{ session_id: string; content: string; score: number }>(
+      "SELECT session_id, content, score FROM session_journal ORDER BY id ASC",
+    )
+    expect(journalRows).toHaveLength(1)
+    expect(journalRows[0].session_id).toBe(sessionId)
+    expect(journalRows[0].content).toContain('Root cause')
+    expect(journalRows[0].content).not.toContain('[intent]')
+    expect(journalRows[0].content).not.toContain('Fix the login bug in auth.ts')
+    expect(journalRows[0].score).toBeGreaterThanOrEqual(2) // outcome fixture clears scorer
   })
 
-  it('is idempotent: repeat call returns existing memory id', async () => {
+  it('is idempotent: repeat call dedupes via content_hash UNIQUE INDEX', async () => {
     const first = await postJson(`http://127.0.0.1:${port}/session/end`, { sessionId })
-    const firstBody = first.body as { memoriesSaved: number[]; alreadyHarvested?: boolean }
-    expect(firstBody.memoriesSaved).toHaveLength(1)
-    expect(firstBody.alreadyHarvested).toBeUndefined()
-    const firstId = firstBody.memoriesSaved[0]
+    const firstBody = first.body as { journalSaved: number[] }
+    expect(firstBody.journalSaved).toHaveLength(1)
 
     const second = await postJson(`http://127.0.0.1:${port}/session/end`, { sessionId })
-    const secondBody = second.body as { memoriesSaved: number[]; alreadyHarvested?: boolean }
-    expect(secondBody.memoriesSaved).toEqual([firstId])
-    expect(secondBody.alreadyHarvested).toBe(true)
-    expect(db.getMemoryCount()).toBe(1)
+    const secondBody = second.body as { journalSaved: number[] }
+    expect(secondBody.journalSaved).toHaveLength(0) // dedup → no new write
+
+    expect(db.getJournalPendingCount()).toBe(1)
   })
 
   it('respects dryRun: returns candidate but does not save', async () => {
@@ -167,18 +170,18 @@ describe('POST /session/end — outcome-bearing session', () => {
     expect(status).toBe(200)
     const b = body as {
       ok: boolean
-      memoriesSaved: number[]
+      journalSaved: number[]
       dryRun: boolean
-      candidate: { content: string; type: string }
+      candidate: { content: string; score: number }
     }
-    expect(b.memoriesSaved).toHaveLength(0)
+    expect(b.journalSaved).toHaveLength(0)
     expect(b.dryRun).toBe(true)
     expect(b.candidate.content).toContain('Root cause')
-    expect(db.getMemoryCount()).toBe(0)
+    expect(db.getJournalPendingCount()).toBe(0)
   })
 })
 
-describe('POST /session/end — sub-threshold session (no harvest)', () => {
+describe('POST /session/end — sub-threshold session (P1: still journals, no threshold gate)', () => {
   let tmpDir: string
   let db: Database
   let server: http.Server
@@ -212,17 +215,22 @@ describe('POST /session/end — sub-threshold session (no harvest)', () => {
     await rm(tmpDir, { recursive: true, force: true })
   })
 
-  it('skips memory but keeps session row when no candidate clears threshold', async () => {
+  // P1 (#21): 移除 score >= 2 persistence gate。sub-threshold candidate
+  // (例如 "I cannot tell time directly.") 仍會進 journal,只要不是 noise / process-report。
+  // 但若 summarizer extractOutcome 因 fixture 太短、無 substantial assistant 而沒產
+  // candidateText, harvest_text 仍是 null,journal 也不會寫。本 fixture 屬後者。
+  it('produces no harvest candidate when session lacks substantial assistant text', async () => {
     const { status, body } = await postJson(`http://127.0.0.1:${port}/session/end`, {
       sessionId,
     })
     expect(status).toBe(200)
-    const b = body as { ok: boolean; memoriesSaved: number[]; reason?: string }
+    const b = body as { ok: boolean; journalSaved: number[]; reason?: string }
     expect(b.ok).toBe(true)
-    expect(b.memoriesSaved).toHaveLength(0)
+    expect(b.journalSaved).toHaveLength(0)
     expect(b.reason).toBeTruthy()
 
     expect(db.getSessionById(sessionId)).not.toBeNull()
+    expect(db.getJournalPendingCount()).toBe(0)
     expect(db.getMemoryCount()).toBe(0)
   })
 })
@@ -265,16 +273,16 @@ describe('POST /session/end — rescue reindex (fresh session race)', () => {
     await rm(tmpDir, { recursive: true, force: true })
   })
 
-  it('rescues a fresh session: reindexes on miss then harvests', async () => {
+  it('rescues a fresh session: reindexes on miss then harvests to journal', async () => {
     expect(db.getSessionById(freshSessionId)).toBeNull()
 
     const { status, body } = await postJson(`http://127.0.0.1:${port}/session/end`, {
       sessionId: freshSessionId,
     })
     expect(status).toBe(200)
-    const b = body as { ok: boolean; memoriesSaved: number[] }
+    const b = body as { ok: boolean; journalSaved: number[] }
     expect(b.ok).toBe(true)
-    expect(b.memoriesSaved).toHaveLength(1)
+    expect(b.journalSaved).toHaveLength(1)
     expect(db.getSessionById(freshSessionId)).not.toBeNull()
   })
 
@@ -329,19 +337,20 @@ describe('session-end helpers (unit)', () => {
   }
 
   it('inferConfidence: committed 0.9, tested 0.8, else 0.7', () => {
+    // 留給 promote 路徑 (C4) 在升級 journal entry 到 memories 時推導 confidence。
     expect(inferConfidence('committed')).toBe(0.9)
     expect(inferConfidence('tested')).toBe(0.8)
     expect(inferConfidence('in-progress')).toBe(0.7)
     expect(inferConfidence(null)).toBe(0.7)
   })
 
-  it('buildMemoryFromSession: returns null when harvestText empty', () => {
-    expect(buildMemoryFromSession({ ...baseSession, harvestText: null })).toBeNull()
-    expect(buildMemoryFromSession({ ...baseSession, harvestText: '   ' })).toBeNull()
+  it('buildJournalCandidate: returns null when harvestText empty', () => {
+    expect(buildJournalCandidate({ ...baseSession, harvestText: null })).toBeNull()
+    expect(buildJournalCandidate({ ...baseSession, harvestText: '   ' })).toBeNull()
   })
 
-  it('buildMemoryFromSession: content is harvestText verbatim — no [intent] prefix, no summary join', () => {
-    const result = buildMemoryFromSession(baseSession)
+  it('buildJournalCandidate: content is harvestText verbatim — no [intent] prefix, no summary join', () => {
+    const result = buildJournalCandidate(baseSession)
     expect(result).not.toBeNull()
     expect(result!.content).toBe(baseSession.harvestText!.trim())
     expect(result!.content).not.toContain('[intent]')
@@ -351,29 +360,18 @@ describe('session-end helpers (unit)', () => {
     expect(result!.messageId).toBeNull()
   })
 
-  it('buildMemoryFromSession: type=query invariant across ALL outcomes (Issue #19), confidence varies', () => {
-    // Pre-0.2.5 harvester used outcome→decision/discovery classification. 0.2.5
-    // hard-coded type='query' to drop classification; #18 keeps that invariant
-    // unchanged while switching the source from intent to harvestText. Auto-
-    // harvest type must remain 'query' for every outcome value — semantic kind
-    // (decision/discovery) stays the realm of explicit recall_save until #21.
-    const cases: Array<[OutcomeStatus, number]> = [
-      ['committed', 0.9],
-      ['tested', 0.8],
-      ['in-progress', 0.7],
-      [null, 0.7],
-    ]
-    for (const [outcome, expectedConfidence] of cases) {
-      const result = buildMemoryFromSession({ ...baseSession, outcomeStatus: outcome })
-      expect(result!.type).toBe('query')
-      expect(result!.confidence).toBe(expectedConfidence)
-    }
+  it('buildJournalCandidate: stores score and reasonsJson from re-scoring', () => {
+    const result = buildJournalCandidate(baseSession)
+    expect(result).not.toBeNull()
+    expect(result!.score).toBeGreaterThanOrEqual(2) // outcome fixture clears scorer
+    const reasons = JSON.parse(result!.reasonsJson!)
+    expect(Array.isArray(reasons)).toBe(true)
+    expect(reasons.length).toBeGreaterThan(0)
   })
 
-  it('buildMemoryFromSession: ignores intent / summary / outcome when harvestText is null', () => {
-    // Old source (intentText + summaryText) MUST NOT leak back as a fallback —
-    // otherwise the 60-80% planned write reduction collapses.
-    const result = buildMemoryFromSession({
+  it('buildJournalCandidate: ignores intent / summary / outcome when harvestText is null', () => {
+    // Old source (intentText + summaryText) MUST NOT leak back as a fallback.
+    const result = buildJournalCandidate({
       ...baseSession,
       harvestText: null,
       intentText: 'A real-looking decision intent',
@@ -381,5 +379,15 @@ describe('session-end helpers (unit)', () => {
       outcomeStatus: 'committed',
     })
     expect(result).toBeNull()
+  })
+
+  it('buildJournalCandidate: hard-floor short-circuits noise / process-report (defense in depth)', () => {
+    // process-report (save-t style 收尾報告) 即便繞過 summarizer 直接餵 SessionMeta
+    // 也應被 buildJournalCandidate 擋下,否則 journal 會被 process meta 污染。
+    const processReport = buildJournalCandidate({
+      ...baseSession,
+      harvestText: '## save-t 完成 ✓\n\n寫入摘要表格',
+    })
+    expect(processReport).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- Architectural fix for [#21](https://github.com/tznthou/ccRecall/issues/21): move the rule scorer off the persistence gate. Harvest now writes to a low-trust `session_journal`; promotion is manual via `ccmem promote <id>`; `recall_save` still writes `memories` directly.
- Schema v22 migration runs automatically on first daemon start; existing memories are not touched.
- 10 commits (6 P1 features + 3 GoGo polish + 1 docs); 562 tests across 37 files; build / lint clean.

## Why

A corpus audit on 39 known-good outcomes returned **0** over `KNOWLEDGE_THRESHOLD` — the scorer was systematically under-weighting real outcomes (failure modes catalogued in [#25](https://github.com/tznthou/ccRecall/issues/25)). Adding more regex patterns would have only delayed the next failure mode. The structural fix splits trust grade from persistence: harvest always lands somewhere; the scorer informs trust grade and promotion priority instead of yes/no.

Two tables, two trust levels:

| Table | Write path | Trust | Read path |
|---|---|---|---|
| `session_journal` | SessionEnd hook (auto) | Low | `/journal/pending`, `/health.journalPendingCount` |
| `memories` | `recall_save` (manual) **or** `ccmem promote` | High | `recall_query`, `recall_context`, `/memory/query` |

## Acceptance criteria (from plan-critic v2)

| Day | Indicator | Threshold | Failure reading |
|-----|-----------|-----------|-----------------|
| 14  | journal write count | ≥ 50 | gate-removal did not unblock — issue is upstream of \`pickLastSubstantialAssistant\` |
| 30  | manual promote count | ≥ 3  | surfacing is insufficient — escalate to #21 P2 (promotion UX) |

Full failure-reading rationale in [CHANGELOG v0.3.0](https://github.com/tznthou/ccRecall/blob/feat/p1-session-journal/CHANGELOG.md#030--2026-05-06).

## Quality pipeline

- **plan-critic v2** — both rounds PASS (trust_level 4→3, scorer_version dropped, manual-only promotion confirmed, success metrics + migration pre-check added)
- **Codex review** — 4 issues fixed (UNIQUE composite key for cross-session leakage, outcome-extractor leftover gate, missing list endpoint, promote race guard)
- **Simplify** — 3 fixes (−155 LOC) via shared `postJson` / `fetchJson`, `parseJsonBody` helper, `JournalRow` mapping
- **Security lint** — 1 medium fix (A08 log injection scrub on `Unhandled error`)

## Test plan

- [ ] \`pnpm vitest run\` — expect 562 passed across 37 files
- [ ] \`pnpm build\` clean
- [ ] \`pnpm eslint .\` clean
- [ ] Manual smoke: \`ccmem promote\` + \`ccmem reject\` round-trip against a fresh DB
- [ ] Verify \`/journal/pending\` returns and \`/health.journalPendingCount\` increments after a SessionEnd
- [ ] On merge to main: confirm OIDC publish workflow triggers; before pushing the v0.3.0 tag, verify \`git show v0.3.0:package.json | grep version\` shows \`0.3.0\` (the missing-bump trap that caught us on v0.2.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)