### PR TITLE
feat: v0.3.2 recall_hit_rate metric instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,50 @@ more like an iteration counter than a strict SemVer major).
 
 ---
 
+## [0.3.2] — 2026-05-21
+
+### Added
+
+- **`recall_query` telemetry for hit-rate analysis.** Every `GET /memory/query`
+  call now appends one JSONL row to `~/.ccrecall/recall-query.log.jsonl`:
+  truncated query (80 chars), original `queryLen`, `hitCount`, `projectId`,
+  `limit`, `maxTokens`. Append failures are swallowed — telemetry must never
+  affect endpoint response. Two opt-out knobs:
+  `CCRECALL_RECALL_TELEMETRY_OFF=1` disables writes; `CCRECALL_RECALL_TELEMETRY_PATH`
+  redirects the log (used by the test suite to keep host telemetry clean).
+
+- **`scripts/recall-hit-rate-report.ts` analysis tool.** Reads the telemetry log
+  and cross-references the `memories` table to split zero-hit queries into two
+  buckets — *literal mismatch* (keyword appears in some memory body but FTS5
+  missed it) vs *truly absent* (keyword nowhere in any memory). Output (markdown
+  or `--json`): totals, hit rate, zero-hit breakdown, per-project counts,
+  query-length percentiles, and up to 10 samples per category. Designed as the
+  L0 quick-fix that feeds the v0.4.0 batch ordering: 1 day of instrumentation +
+  7 days of observation → evidence-driven decision between `#28` surfacing UX,
+  `#15` tag first-class + Topic CJK, and `#29` scorer epistemic.
+
+### Why
+
+The cold-rate signal (96/116 memories never recalled, 4 batches of major events
+that landed in auto memory instead of ccRecall DB) needs an evidence base before
+the v0.4.0 batch can pick a direction. This release is pure instrumentation —
+no scoring, schema, or recall behaviour changes — so the 7-day observation
+period stays clean.
+
+### Notes
+
+- Privacy: query string is truncated to 80 chars before logging. `queryLen`
+  preserves the original length so we can still characterise long-query
+  distribution. Hashing was considered and rejected because hashing would
+  prevent the substring cross-reference that splits literal-mismatch from
+  truly-absent.
+- Performance: `appendFileSync` runs on the response path; E2E tests assert the
+  total round-trip stays under 100ms even with telemetry on.
+- This release does NOT flip `CCRECALL_SESSION_START_STRATEGY` default — that
+  ships with v0.4.0 once the metric evidence is in.
+
+---
+
 ## [0.3.1] — 2026-05-13
 
 ### Fixed

--- a/CHANGELOG_ZH.md
+++ b/CHANGELOG_ZH.md
@@ -8,6 +8,44 @@ ccRecall 的重要版本變更記錄在這裡。
 
 ---
 
+## [0.3.2] — 2026-05-21
+
+### 新增
+
+- **`recall_query` telemetry,為 hit-rate 分析鋪基。** 每次 `GET /memory/query`
+  呼叫現在會 append 一筆 JSONL 到 `~/.ccrecall/recall-query.log.jsonl`:
+  truncate 過的 query(80 chars)、原始 `queryLen`、`hitCount`、`projectId`、
+  `limit`、`maxTokens`。Append 失敗會被吞掉 — telemetry 絕不能影響 endpoint
+  回應。兩個 opt-out 開關:`CCRECALL_RECALL_TELEMETRY_OFF=1` 關掉寫入;
+  `CCRECALL_RECALL_TELEMETRY_PATH` 改寫 log 路徑(test 用,避免污染 host 真實 log)。
+
+- **`scripts/recall-hit-rate-report.ts` 分析腳本。** 讀 telemetry log + 對照
+  `memories` 表,把 zero-hit query 拆兩桶 — *literal mismatch*(keyword 出現在
+  某筆 memory body 但 FTS5 沒抓到) vs *truly absent*(keyword 不存在任一
+  memory)。輸出(markdown 或 `--json`):總數、hit rate、zero-hit 拆分、
+  per-project 計數、query length 分布、每類最多 10 筆 sample。設計為 L0
+  quick-fix 餵 v0.4.0 batch 排序:1 天 instrumentation + 7 天觀察 → 用實證
+  決定 `#28` surfacing UX、`#15` tag first-class + Topic CJK、`#29` scorer
+  epistemic 之間的優先序。
+
+### 為什麼
+
+Cold rate 訊號(116 筆 memories 96 筆從未召回,4 批重大事件落到 auto memory
+而非 ccRecall DB)需要 evidence 基底才能決定 v0.4.0 batch 方向。本版純
+instrumentation — 不動 scoring、schema、recall 行為 — 讓 7 天觀察期保持乾淨。
+
+### 備註
+
+- Privacy:query 字串 log 前 truncate 到 80 chars。`queryLen` 保留原長度可看
+  長 query 分布。考慮過 hashing 但拒絕,因為 hashing 會阻擋拆分 literal
+  mismatch / truly absent 所需的 substring 對照。
+- 效能:`appendFileSync` 跑在 response path 上;E2E test 驗證 telemetry 開
+  狀態下整段 round-trip 仍 < 100ms。
+- 本版**不**翻 `CCRECALL_SESSION_START_STRATEGY` 預設值 — 等 metric 證據到位後
+  跟 v0.4.0 一起出。
+
+---
+
 ## [0.3.1] — 2026-05-13
 
 ### 修正

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tznthou/ccrecall",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "AI memory service for Claude Code — on-demand context injection with metacognition",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/recall-hit-rate-report.ts
+++ b/scripts/recall-hit-rate-report.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// recall_hit_rate analysis script — reads telemetry log, cross-references
+// memories DB, prints cold-rate root-cause breakdown.
+//
+// Usage:
+//   pnpm tsx scripts/recall-hit-rate-report.ts
+//   pnpm tsx scripts/recall-hit-rate-report.ts --log <path> --db <path> --json
+
+import { readFileSync, existsSync } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import BetterSqlite3 from 'better-sqlite3'
+import {
+  analyzeRecallTelemetry,
+  formatRecallHitRateReport,
+} from '../src/core/recall-hit-rate-report.js'
+import type { RecallTelemetryEntry } from '../src/core/recall-telemetry.js'
+
+interface CliArgs {
+  logPath: string
+  dbPath: string
+  json: boolean
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    logPath: path.join(os.homedir(), '.ccrecall', 'recall-query.log.jsonl'),
+    dbPath: path.join(os.homedir(), '.ccrecall', 'ccrecall.db'),
+    json: false,
+  }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--log' && argv[i + 1]) {
+      args.logPath = argv[++i]
+    } else if (a === '--db' && argv[i + 1]) {
+      args.dbPath = argv[++i]
+    } else if (a === '--json') {
+      args.json = true
+    } else if (a === '-h' || a === '--help') {
+      process.stdout.write(
+        'Usage: pnpm tsx scripts/recall-hit-rate-report.ts [--log <path>] [--db <path>] [--json]\n',
+      )
+      process.exit(0)
+    }
+  }
+  return args
+}
+
+function readTelemetryLog(logPath: string): RecallTelemetryEntry[] {
+  if (!existsSync(logPath)) {
+    process.stderr.write(`telemetry log not found: ${logPath}\n`)
+    process.exit(1)
+  }
+  const raw = readFileSync(logPath, 'utf8')
+  const entries: RecallTelemetryEntry[] = []
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue
+    try {
+      entries.push(JSON.parse(line) as RecallTelemetryEntry)
+    } catch {
+      // skip malformed lines (forward-compat with future schema changes)
+    }
+  }
+  return entries
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2))
+  const entries = readTelemetryLog(args.logPath)
+
+  if (!existsSync(args.dbPath)) {
+    process.stderr.write(`db not found: ${args.dbPath}\n`)
+    process.exit(1)
+  }
+
+  const db = new BetterSqlite3(args.dbPath, { readonly: true, fileMustExist: true })
+  const stmt = db.prepare('SELECT 1 FROM memories WHERE content LIKE ? LIMIT 1')
+  const matcher = (q: string): boolean => stmt.get(`%${q}%`) !== undefined
+
+  const analysis = analyzeRecallTelemetry(entries, matcher)
+  db.close()
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify(analysis, null, 2) + '\n')
+  } else {
+    process.stdout.write(formatRecallHitRateReport(analysis) + '\n')
+  }
+}
+
+main()

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -8,6 +8,7 @@ import { runLint } from '../core/lint.js'
 import { scrubErrorMessage } from '../core/log-safe.js'
 import { scoreKnowledgeBearing } from '../core/outcome-scorer.js'
 import { applyRowBudget, DEFAULT_MAX_TOKENS, DEFAULT_PER_ROW_CHAR_CAP } from '../core/token-budget.js'
+import { appendRecallTelemetry } from '../core/recall-telemetry.js'
 import type {
   HealthResult, Memory, MemoryType, SessionMeta, OutcomeStatus,
   KnowledgeDepth, Topic, TopicDetail, MetacognitionSummary, CheckpointResult,
@@ -265,6 +266,14 @@ export function createRequestHandler(
         truncated: budgeted.truncated,
         query: q,
         limit,
+      })
+
+      appendRecallTelemetry({
+        query: q,
+        hitCount: memories.length,
+        projectId: project,
+        limit,
+        maxTokens,
       })
       return
     }

--- a/src/core/recall-hit-rate-report.ts
+++ b/src/core/recall-hit-rate-report.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { RecallTelemetryEntry } from './recall-telemetry.js'
+
+const SAMPLE_CAP = 10
+
+/** Given a (possibly truncated) query string, return whether ANY memory.content
+ *  contains it as a substring. Injected so the analyzer stays pure / testable. */
+export type ContentMatcher = (query: string) => boolean
+
+export interface ProjectBucket {
+  total: number
+  hit: number
+  zeroHit: number
+}
+
+export interface QueryLenPercentiles {
+  p50: number
+  p90: number
+  p99: number
+  max: number
+}
+
+export interface RecallHitRateAnalysis {
+  totalQueries: number
+  hitCount: number
+  zeroHitCount: number
+  literalMismatch: number
+  trulyAbsent: number
+  hitRate: number
+  literalMismatchRate: number
+  byProject: Record<string, ProjectBucket>
+  queryLenDistribution: QueryLenPercentiles
+  samples: {
+    literalMismatch: Array<{ query: string; queryLen: number }>
+    trulyAbsent: Array<{ query: string; queryLen: number }>
+  }
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0
+  const idx = Math.min(sorted.length - 1, Math.floor(sorted.length * p))
+  return sorted[idx]
+}
+
+export function analyzeRecallTelemetry(
+  entries: RecallTelemetryEntry[],
+  matchesAnyMemory: ContentMatcher,
+): RecallHitRateAnalysis {
+  const total = entries.length
+  let hitCount = 0
+  let zeroHitCount = 0
+  let literalMismatch = 0
+  let trulyAbsent = 0
+  const byProject: Record<string, ProjectBucket> = {}
+  const literalMismatchSamples: Array<{ query: string; queryLen: number }> = []
+  const trulyAbsentSamples: Array<{ query: string; queryLen: number }> = []
+  const queryLens: number[] = []
+
+  for (const e of entries) {
+    queryLens.push(e.queryLen)
+
+    const proj = e.projectId ?? '(none)'
+    if (!byProject[proj]) byProject[proj] = { total: 0, hit: 0, zeroHit: 0 }
+    byProject[proj].total++
+
+    if (e.hitCount > 0) {
+      hitCount++
+      byProject[proj].hit++
+    } else {
+      zeroHitCount++
+      byProject[proj].zeroHit++
+
+      if (matchesAnyMemory(e.query)) {
+        literalMismatch++
+        if (literalMismatchSamples.length < SAMPLE_CAP) {
+          literalMismatchSamples.push({ query: e.query, queryLen: e.queryLen })
+        }
+      } else {
+        trulyAbsent++
+        if (trulyAbsentSamples.length < SAMPLE_CAP) {
+          trulyAbsentSamples.push({ query: e.query, queryLen: e.queryLen })
+        }
+      }
+    }
+  }
+
+  queryLens.sort((a, b) => a - b)
+
+  return {
+    totalQueries: total,
+    hitCount,
+    zeroHitCount,
+    literalMismatch,
+    trulyAbsent,
+    hitRate: total === 0 ? 0 : hitCount / total,
+    literalMismatchRate: zeroHitCount === 0 ? 0 : literalMismatch / zeroHitCount,
+    byProject,
+    queryLenDistribution: {
+      p50: percentile(queryLens, 0.5),
+      p90: percentile(queryLens, 0.9),
+      p99: percentile(queryLens, 0.99),
+      max: queryLens.length === 0 ? 0 : queryLens[queryLens.length - 1],
+    },
+    samples: {
+      literalMismatch: literalMismatchSamples,
+      trulyAbsent: trulyAbsentSamples,
+    },
+  }
+}
+
+export function formatRecallHitRateReport(a: RecallHitRateAnalysis): string {
+  const pct = (n: number) => `${(n * 100).toFixed(1)}%`
+  const lines: string[] = []
+
+  lines.push('# recall_hit_rate report')
+  lines.push('')
+  lines.push('## Totals')
+  lines.push('')
+  lines.push(`- Total queries: ${a.totalQueries}`)
+  lines.push(`- Hit (≥1 memory): ${a.hitCount} (${pct(a.hitRate)})`)
+  lines.push(`- Zero-hit: ${a.zeroHitCount}`)
+  lines.push('')
+  lines.push('## Zero-hit breakdown (cold rate root cause)')
+  lines.push('')
+  lines.push(`- Literal mismatch (keyword in DB but query missed): ${a.literalMismatch} (${pct(a.literalMismatchRate)} of zero-hit)`)
+  lines.push(`- Truly absent (keyword NOT in any memory): ${a.trulyAbsent}`)
+  lines.push('')
+  lines.push('## By project')
+  lines.push('')
+  lines.push('| projectId | total | hit | zeroHit |')
+  lines.push('|---|---|---|---|')
+  for (const [proj, b] of Object.entries(a.byProject)) {
+    lines.push(`| ${proj} | ${b.total} | ${b.hit} | ${b.zeroHit} |`)
+  }
+  lines.push('')
+  lines.push('## Query length distribution')
+  lines.push('')
+  lines.push(`- p50: ${a.queryLenDistribution.p50}`)
+  lines.push(`- p90: ${a.queryLenDistribution.p90}`)
+  lines.push(`- p99: ${a.queryLenDistribution.p99}`)
+  lines.push(`- max: ${a.queryLenDistribution.max}`)
+  lines.push('')
+  if (a.samples.literalMismatch.length > 0) {
+    lines.push('## Sample: literal mismatch (top 10)')
+    lines.push('')
+    for (const s of a.samples.literalMismatch) {
+      lines.push(`- \`${s.query}\` (len ${s.queryLen})`)
+    }
+    lines.push('')
+  }
+  if (a.samples.trulyAbsent.length > 0) {
+    lines.push('## Sample: truly absent (top 10)')
+    lines.push('')
+    for (const s of a.samples.trulyAbsent) {
+      lines.push(`- \`${s.query}\` (len ${s.queryLen})`)
+    }
+    lines.push('')
+  }
+  return lines.join('\n')
+}

--- a/src/core/recall-telemetry.ts
+++ b/src/core/recall-telemetry.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+import { mkdirSync, appendFileSync } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+
+const QUERY_TRUNCATE_LEN = 80
+
+export interface RecallTelemetryInput {
+  query: string
+  hitCount: number
+  projectId?: string | null
+  limit: number
+  maxTokens?: number | null
+}
+
+export interface RecallTelemetryEntry {
+  ts: string
+  query: string
+  queryLen: number
+  hitCount: number
+  projectId: string | null
+  limit: number
+  maxTokens: number | null
+}
+
+function defaultTelemetryPath(): string {
+  return path.join(os.homedir(), '.ccrecall', 'recall-query.log.jsonl')
+}
+
+function resolveTelemetryPath(override?: string): string {
+  if (override) return override
+  const envPath = process.env.CCRECALL_RECALL_TELEMETRY_PATH
+  if (envPath) return envPath
+  return defaultTelemetryPath()
+}
+
+export function buildRecallTelemetryEntry(
+  input: RecallTelemetryInput,
+  now: Date = new Date(),
+): RecallTelemetryEntry {
+  return {
+    ts: now.toISOString(),
+    query: input.query.slice(0, QUERY_TRUNCATE_LEN),
+    queryLen: input.query.length,
+    hitCount: input.hitCount,
+    projectId: input.projectId ?? null,
+    limit: input.limit,
+    maxTokens: input.maxTokens ?? null,
+  }
+}
+
+export function appendRecallTelemetry(
+  input: RecallTelemetryInput,
+  options: { pathOverride?: string; now?: Date } = {},
+): void {
+  if (process.env.CCRECALL_RECALL_TELEMETRY_OFF === '1') return
+
+  const telemetryPath = resolveTelemetryPath(options.pathOverride)
+  const entry = buildRecallTelemetryEntry(input, options.now)
+
+  try {
+    mkdirSync(path.dirname(telemetryPath), { recursive: true, mode: 0o700 })
+    appendFileSync(telemetryPath, JSON.stringify(entry) + '\n', { mode: 0o600 })
+  } catch {
+    // telemetry write must never affect endpoint response;
+    // swallow errors (privilege issues, disk full, etc.)
+  }
+}

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, mkdir, writeFile, readFile } from 'node:fs/promises'
 import path from 'node:path'
 import os from 'node:os'
 import http from 'node:http'
@@ -14,6 +14,8 @@ describe('E2E: index → search → HTTP', () => {
   let db: Database
   let server: http.Server
   let port: number
+  const originalTelemetryPath = process.env.CCRECALL_RECALL_TELEMETRY_PATH
+  const originalTelemetryOff = process.env.CCRECALL_RECALL_TELEMETRY_OFF
 
   // issue #18: harvest source switched from first user prompt to scored outcome
   // cluster — sample needs commit invocation + a last assistant message that
@@ -42,6 +44,11 @@ describe('E2E: index → search → HTTP', () => {
     // Run indexer
     await runIndexer(db, undefined, path.join(tmpDir, 'projects'))
 
+    // Isolate recall-telemetry writes so /memory/query tests don't append
+    // to the real ~/.ccrecall/recall-query.log.jsonl on the host.
+    process.env.CCRECALL_RECALL_TELEMETRY_PATH = path.join(tmpDir, 'recall-query.log.jsonl')
+    delete process.env.CCRECALL_RECALL_TELEMETRY_OFF
+
     // Start server on random port
     server = createServer(db)
     await new Promise<void>((resolve) => {
@@ -55,6 +62,16 @@ describe('E2E: index → search → HTTP', () => {
   afterEach(async () => {
     server.close()
     db.close()
+    if (originalTelemetryPath === undefined) {
+      delete process.env.CCRECALL_RECALL_TELEMETRY_PATH
+    } else {
+      process.env.CCRECALL_RECALL_TELEMETRY_PATH = originalTelemetryPath
+    }
+    if (originalTelemetryOff === undefined) {
+      delete process.env.CCRECALL_RECALL_TELEMETRY_OFF
+    } else {
+      process.env.CCRECALL_RECALL_TELEMETRY_OFF = originalTelemetryOff
+    }
     await rm(tmpDir, { recursive: true, force: true })
   })
 
@@ -134,6 +151,54 @@ describe('E2E: index → search → HTTP', () => {
     expect(b.totalTokenEstimate).toBeLessThanOrEqual(50)
     // truncated should fire on at least one of them
     expect(b.truncated || b.droppedCount > 0).toBe(true)
+  })
+
+  it('GET /memory/query writes telemetry row per call (with 80-char query truncation)', async () => {
+    await postJson(`http://127.0.0.1:${port}/memory/save`, {
+      content: 'evidence-first debugging principles',
+      type: 'pattern',
+      projectId: '-test-project',
+      confidence: 0.8,
+    })
+
+    await fetch(`http://127.0.0.1:${port}/memory/query?q=evidence&limit=5&project=-test-project`)
+
+    const longQuery = 'a'.repeat(200)
+    await fetch(`http://127.0.0.1:${port}/memory/query?q=${encodeURIComponent(longQuery)}&limit=5`)
+
+    const logPath = process.env.CCRECALL_RECALL_TELEMETRY_PATH!
+    const content = await readFile(logPath, 'utf8')
+    const lines = content.trim().split('\n')
+    expect(lines.length).toBe(2)
+
+    const row1 = JSON.parse(lines[0])
+    expect(row1.query).toBe('evidence')
+    expect(row1.queryLen).toBe(8)
+    expect(row1.hitCount).toBeGreaterThan(0)
+    expect(row1.projectId).toBe('-test-project')
+    expect(row1.limit).toBe(5)
+    expect(row1.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+
+    const row2 = JSON.parse(lines[1])
+    expect(row2.query.length).toBe(80)
+    expect(row2.queryLen).toBe(200)
+    expect(row2.hitCount).toBe(0)
+  })
+
+  it('GET /memory/query telemetry write does not block endpoint (timing under 100ms wall)', async () => {
+    await postJson(`http://127.0.0.1:${port}/memory/save`, {
+      content: 'telemetry timing sentinel',
+      type: 'discovery',
+      projectId: '-test-project',
+    })
+
+    const t0 = Date.now()
+    await fetch(`http://127.0.0.1:${port}/memory/query?q=telemetry&limit=5&project=-test-project`)
+    const elapsed = Date.now() - t0
+    // Wall-time budget is generous (100ms) to absorb CI flake; the goal is to
+    // catch a regression where appendFileSync blocks for hundreds of ms,
+    // not to micro-benchmark sync I/O.
+    expect(elapsed).toBeLessThan(100)
   })
 
   it('GET /memory/startup surfaces project memory NOT containing project name (closes echo chamber)', async () => {

--- a/tests/recall-hit-rate-report.test.ts
+++ b/tests/recall-hit-rate-report.test.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect } from 'vitest'
+import {
+  analyzeRecallTelemetry,
+  formatRecallHitRateReport,
+} from '../src/core/recall-hit-rate-report'
+import type { RecallTelemetryEntry } from '../src/core/recall-telemetry'
+
+function entry(over: Partial<RecallTelemetryEntry> = {}): RecallTelemetryEntry {
+  return {
+    ts: '2026-05-21T00:00:00.000Z',
+    query: 'q',
+    queryLen: 1,
+    hitCount: 0,
+    projectId: null,
+    limit: 5,
+    maxTokens: null,
+    ...over,
+  }
+}
+
+describe('analyzeRecallTelemetry', () => {
+  it('returns all zeros for empty input', () => {
+    const a = analyzeRecallTelemetry([], () => false)
+    expect(a.totalQueries).toBe(0)
+    expect(a.hitRate).toBe(0)
+    expect(a.literalMismatchRate).toBe(0)
+    expect(a.queryLenDistribution.p50).toBe(0)
+  })
+
+  it('100% hit when every entry has hitCount > 0', () => {
+    const entries = [
+      entry({ query: 'q1', hitCount: 1 }),
+      entry({ query: 'q2', hitCount: 3 }),
+    ]
+    const a = analyzeRecallTelemetry(entries, () => false)
+    expect(a.hitCount).toBe(2)
+    expect(a.zeroHitCount).toBe(0)
+    expect(a.hitRate).toBe(1)
+    expect(a.literalMismatch).toBe(0)
+    expect(a.trulyAbsent).toBe(0)
+  })
+
+  it('classifies zero-hit by matcher: matcher true → literalMismatch', () => {
+    const entries = [
+      entry({ query: 'echo chamber', hitCount: 0 }),
+      entry({ query: 'foo bar', hitCount: 0 }),
+    ]
+    const a = analyzeRecallTelemetry(entries, (q) => q === 'echo chamber')
+    expect(a.literalMismatch).toBe(1)
+    expect(a.trulyAbsent).toBe(1)
+    expect(a.zeroHitCount).toBe(2)
+    expect(a.literalMismatchRate).toBe(0.5)
+  })
+
+  it('groups by projectId and uses "(none)" for null', () => {
+    const entries = [
+      entry({ projectId: '-A', hitCount: 1 }),
+      entry({ projectId: '-A', hitCount: 0 }),
+      entry({ projectId: '-B', hitCount: 2 }),
+      entry({ projectId: null, hitCount: 0 }),
+    ]
+    const a = analyzeRecallTelemetry(entries, () => false)
+    expect(a.byProject['-A']).toEqual({ total: 2, hit: 1, zeroHit: 1 })
+    expect(a.byProject['-B']).toEqual({ total: 1, hit: 1, zeroHit: 0 })
+    expect(a.byProject['(none)']).toEqual({ total: 1, hit: 0, zeroHit: 1 })
+  })
+
+  it('computes queryLenDistribution percentiles', () => {
+    const entries = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map((n) =>
+      entry({ queryLen: n, hitCount: 1 }),
+    )
+    const a = analyzeRecallTelemetry(entries, () => false)
+    expect(a.queryLenDistribution.p50).toBe(60)
+    expect(a.queryLenDistribution.p90).toBe(100)
+    expect(a.queryLenDistribution.max).toBe(100)
+  })
+
+  it('caps samples at 10 per category', () => {
+    const entries = Array.from({ length: 25 }, (_, i) =>
+      entry({ query: `q${i}`, hitCount: 0 }),
+    )
+    const a = analyzeRecallTelemetry(entries, () => true)
+    expect(a.literalMismatch).toBe(25)
+    expect(a.samples.literalMismatch.length).toBe(10)
+  })
+})
+
+describe('formatRecallHitRateReport', () => {
+  it('renders markdown headers and key metrics', () => {
+    const entries = [
+      entry({ query: 'pnpm', hitCount: 2, projectId: '-test' }),
+      entry({ query: 'echo chamber', hitCount: 0, queryLen: 12 }),
+    ]
+    const a = analyzeRecallTelemetry(entries, (q) => q === 'echo chamber')
+    const md = formatRecallHitRateReport(a)
+
+    expect(md).toContain('# recall_hit_rate report')
+    expect(md).toContain('## Totals')
+    expect(md).toContain('Total queries: 2')
+    expect(md).toContain('Hit (≥1 memory): 1 (50.0%)')
+    expect(md).toContain('## Zero-hit breakdown')
+    expect(md).toContain('Literal mismatch')
+    expect(md).toContain('## By project')
+    expect(md).toContain('-test')
+    expect(md).toContain('## Sample: literal mismatch')
+    expect(md).toContain('`echo chamber`')
+  })
+
+  it('skips empty sample sections', () => {
+    const a = analyzeRecallTelemetry([entry({ hitCount: 1 })], () => false)
+    const md = formatRecallHitRateReport(a)
+    expect(md).not.toContain('## Sample: literal mismatch')
+    expect(md).not.toContain('## Sample: truly absent')
+  })
+})

--- a/tests/recall-telemetry.test.ts
+++ b/tests/recall-telemetry.test.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm, readFile, stat } from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import {
+  appendRecallTelemetry,
+  buildRecallTelemetryEntry,
+} from '../src/core/recall-telemetry'
+
+describe('recall-telemetry: buildRecallTelemetryEntry', () => {
+  it('truncates query to 80 chars but preserves original queryLen', () => {
+    const long = 'a'.repeat(200)
+    const entry = buildRecallTelemetryEntry({
+      query: long,
+      hitCount: 3,
+      limit: 5,
+    })
+    expect(entry.query.length).toBe(80)
+    expect(entry.queryLen).toBe(200)
+    expect(entry.hitCount).toBe(3)
+    expect(entry.limit).toBe(5)
+  })
+
+  it('passes short query through unchanged', () => {
+    const entry = buildRecallTelemetryEntry({
+      query: 'ccRecall',
+      hitCount: 1,
+      limit: 5,
+    })
+    expect(entry.query).toBe('ccRecall')
+    expect(entry.queryLen).toBe(8)
+  })
+
+  it('normalises projectId / maxTokens to null when absent', () => {
+    const entry = buildRecallTelemetryEntry({
+      query: 'q',
+      hitCount: 0,
+      limit: 5,
+    })
+    expect(entry.projectId).toBeNull()
+    expect(entry.maxTokens).toBeNull()
+  })
+
+  it('uses injected clock for ts', () => {
+    const fixed = new Date('2026-05-21T10:00:00.000Z')
+    const entry = buildRecallTelemetryEntry(
+      { query: 'q', hitCount: 0, limit: 5 },
+      fixed,
+    )
+    expect(entry.ts).toBe('2026-05-21T10:00:00.000Z')
+  })
+})
+
+describe('recall-telemetry: appendRecallTelemetry', () => {
+  let tmpDir: string
+  let logPath: string
+  const originalOff = process.env.CCRECALL_RECALL_TELEMETRY_OFF
+  const originalPath = process.env.CCRECALL_RECALL_TELEMETRY_PATH
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ccrecall-telemetry-'))
+    logPath = path.join(tmpDir, 'subdir', 'recall-query.log.jsonl')
+    delete process.env.CCRECALL_RECALL_TELEMETRY_OFF
+    delete process.env.CCRECALL_RECALL_TELEMETRY_PATH
+  })
+
+  afterEach(async () => {
+    if (originalOff === undefined) {
+      delete process.env.CCRECALL_RECALL_TELEMETRY_OFF
+    } else {
+      process.env.CCRECALL_RECALL_TELEMETRY_OFF = originalOff
+    }
+    if (originalPath === undefined) {
+      delete process.env.CCRECALL_RECALL_TELEMETRY_PATH
+    } else {
+      process.env.CCRECALL_RECALL_TELEMETRY_PATH = originalPath
+    }
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('writes one JSONL row per call and creates parent dir', async () => {
+    appendRecallTelemetry(
+      { query: 'q1', hitCount: 2, limit: 5, projectId: 'p', maxTokens: 300 },
+      { pathOverride: logPath },
+    )
+    appendRecallTelemetry(
+      { query: 'q2', hitCount: 0, limit: 5 },
+      { pathOverride: logPath },
+    )
+
+    const content = await readFile(logPath, 'utf8')
+    const lines = content.trim().split('\n')
+    expect(lines.length).toBe(2)
+
+    const row1 = JSON.parse(lines[0])
+    expect(row1.query).toBe('q1')
+    expect(row1.hitCount).toBe(2)
+    expect(row1.projectId).toBe('p')
+    expect(row1.maxTokens).toBe(300)
+    expect(row1.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+
+    const row2 = JSON.parse(lines[1])
+    expect(row2.query).toBe('q2')
+    expect(row2.hitCount).toBe(0)
+    expect(row2.projectId).toBeNull()
+  })
+
+  it('skips write when CCRECALL_RECALL_TELEMETRY_OFF=1', async () => {
+    process.env.CCRECALL_RECALL_TELEMETRY_OFF = '1'
+    appendRecallTelemetry(
+      { query: 'q', hitCount: 1, limit: 5 },
+      { pathOverride: logPath },
+    )
+    await expect(stat(logPath)).rejects.toThrow()
+  })
+
+  it('honours CCRECALL_RECALL_TELEMETRY_PATH env when no override given', async () => {
+    process.env.CCRECALL_RECALL_TELEMETRY_PATH = logPath
+    appendRecallTelemetry({ query: 'q', hitCount: 1, limit: 5 })
+    const content = await readFile(logPath, 'utf8')
+    expect(content.trim().split('\n').length).toBe(1)
+  })
+
+  it('fails silently when path is invalid (does not throw)', () => {
+    // Append to a path under a non-writable parent — should not throw.
+    // Use /dev/null as a parent to force ENOTDIR/EACCES.
+    expect(() =>
+      appendRecallTelemetry(
+        { query: 'q', hitCount: 0, limit: 5 },
+        { pathOverride: '/dev/null/subdir/log.jsonl' },
+      ),
+    ).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

- `/memory/query` endpoint now logs one JSONL row per call to `~/.ccrecall/recall-query.log.jsonl` (truncated query 80 chars + queryLen + hitCount + projectId + limit + maxTokens)
- New `scripts/recall-hit-rate-report.ts` analysis tool splits zero-hit queries into *literal mismatch* (keyword in DB but FTS5 missed) vs *truly absent* (keyword nowhere in any memory)
- L0 quick-fix that feeds the v0.4.0 batch ordering: 1 day of instrumentation + 7 days of observation → evidence-driven choice between `#28` surfacing UX, `#15` tag first-class + Topic CJK, `#29` scorer epistemic

## Why

Cold-rate signal (96/116 memories never recalled, 4 batches of major events that landed in auto memory instead of ccRecall DB) needs an evidence base before v0.4.0 can pick a direction. This release is pure instrumentation — no scoring, schema, or recall behaviour changes — so the 7-day observation period stays clean.

## Design choices

- **Privacy**: query truncated to 80 chars before logging; `queryLen` preserves the original length. Hashing was rejected because it would prevent substring cross-reference for literal-mismatch vs truly-absent split.
- **Two env knobs**: `CCRECALL_RECALL_TELEMETRY_OFF=1` disables writes; `CCRECALL_RECALL_TELEMETRY_PATH` redirects log (used by test suite for host isolation).
- **Performance**: `appendFileSync` runs on response path; E2E test asserts round-trip under 100ms with telemetry on. Append failure is swallowed — telemetry must not affect endpoint response.
- **Analyzer pure / DI**: `src/core/recall-hit-rate-report.ts` takes the DB matcher as a parameter so it unit-tests without SQLite. The script (`scripts/recall-hit-rate-report.ts`) is a thin I/O wrapper.

## Out of scope

- Does NOT flip `CCRECALL_SESSION_START_STRATEGY` default (ships with v0.4.0 once metric evidence is in)
- Does NOT touch `hooks-session-start.test.ts` HOME isolation (independent PR)
- No schema migration, no recall_query API contract change

## Test plan

- [x] `pnpm vitest run` — 596/596 pass (+18 new: 8 telemetry unit + 2 e2e integration + 8 report unit)
- [x] `pnpm eslint` — green
- [x] `pnpm tsc --noEmit` — green
- [ ] After merge: tag v0.3.2, OIDC npm publish, daemon `npm install -g @tznthou/ccrecall@0.3.2`, verify `/health` returns version `0.3.2`
- [ ] 7-day observation starts at daemon upgrade; on 2026-05-28 run `pnpm tsx scripts/recall-hit-rate-report.ts` and feed the v0.4.0 ordering decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)