### PR TITLE
fix(mcp): scope recall_query to the current project

### DIFF
--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -36,6 +36,7 @@ function textError(prefix: string, err: unknown): McpTextResult {
 
 const recallQueryInput = {
   query: z.string().min(1).describe('FTS5 search query (keywords or phrase)'),
+  projectId: z.string().min(1).describe('Project ID (derived from cwd, e.g. "-Users-foo-my-project")'),
   limit: z.number().int().positive().max(50).optional().describe('Max results (default 10, max 50)'),
   maxTokens: z.number().int().positive().max(2000).optional().describe(
     `Approximate total output token budget (default ${DEFAULT_MAX_TOKENS}). Results are truncated with per-row ellipsis and a trailer so clipping is always visible.`,
@@ -87,11 +88,11 @@ export function formatMemories(
 export function recallQueryHandler(
   db: Database,
   memoryService: MemoryService,
-  args: { query: string; limit?: number; maxTokens?: number },
+  args: { query: string; projectId: string; limit?: number; maxTokens?: number },
 ): McpTextResult {
   const limit = args.limit ?? 10
   try {
-    const memories = db.queryMemories(args.query, limit)
+    const memories = db.queryMemories(args.query, limit, args.projectId)
     const { text, emittedIds } = formatMemories(memories, args.query, args.maxTokens)
     // Phase 4c: touch only memories that actually reached the caller.
     // Budget-dropped rows are not "surfaced" — bumping their access_count
@@ -102,7 +103,7 @@ export function recallQueryHandler(
     appendRecallTelemetry({
       query: args.query,
       hitCount: emittedIds.length,
-      projectId: null,
+      projectId: args.projectId,
       limit,
       maxTokens: args.maxTokens ?? null,
     })

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -32,7 +32,7 @@ describe('MCP recall_query handler', () => {
   })
 
   it('returns empty-result message when no memories match', () => {
-    const result = recallQueryHandler(db, svc, { query: 'nonexistent' })
+    const result = recallQueryHandler(db, svc, { query: 'nonexistent', projectId: 'proj-a' })
     expect(result.isError).toBeUndefined()
     expect(result.content[0].text).toContain('No memories found')
   })
@@ -44,8 +44,9 @@ describe('MCP recall_query handler', () => {
       content: 'Use Apache-2.0 license for ccRecall',
       type: 'decision',
       confidence: 0.9,
+      projectId: 'proj-a',
     })
-    const result = recallQueryHandler(db, svc, { query: 'Apache' })
+    const result = recallQueryHandler(db, svc, { query: 'Apache', projectId: 'proj-a' })
     expect(result.content[0].text).toContain('[decision]')
     expect(result.content[0].text).toContain('Apache-2.0')
     expect(result.content[0].text).toContain('conf 0.90')
@@ -59,9 +60,10 @@ describe('MCP recall_query handler', () => {
         content: `test memory ${i} apache`,
         type: 'discovery',
         confidence: 1,
+        projectId: 'proj-a',
       })
     }
-    const result = recallQueryHandler(db, svc, { query: 'apache', limit: 2 })
+    const result = recallQueryHandler(db, svc, { query: 'apache', limit: 2, projectId: 'proj-a' })
     const lines = result.content[0].text.split('\n').filter(Boolean)
     expect(lines.length).toBe(2)
   })
@@ -74,9 +76,10 @@ describe('MCP recall_query handler', () => {
         content: `memory ${i} keyword`,
         type: 'pattern',
         confidence: 1,
+        projectId: 'proj-a',
       })
     }
-    const result = recallQueryHandler(db, svc, { query: 'keyword' })
+    const result = recallQueryHandler(db, svc, { query: 'keyword', projectId: 'proj-a' })
     const lines = result.content[0].text.split('\n').filter(Boolean)
     expect(lines.length).toBe(10)
   })
@@ -94,14 +97,16 @@ describe('MCP recall_query handler', () => {
         content: 'apache license decision body',
         type: 'decision',
         confidence: 1,
+        projectId: 'proj-a',
       })
-      recallQueryHandler(db, svc, { query: 'apache', limit: 5 })
+      recallQueryHandler(db, svc, { query: 'apache', limit: 5, projectId: 'proj-a' })
       const lines = readFileSync(logPath, 'utf8').trim().split('\n')
       expect(lines.length).toBe(1)
       const row = JSON.parse(lines[0])
       expect(row.query).toBe('apache')
       expect(row.hitCount).toBe(1)
       expect(row.limit).toBe(5)
+      expect(row.projectId).toBe('proj-a')
     } finally {
       if (original === undefined) delete process.env.CCRECALL_RECALL_TELEMETRY_PATH
       else process.env.CCRECALL_RECALL_TELEMETRY_PATH = original
@@ -113,7 +118,7 @@ describe('MCP recall_query handler', () => {
     const original = process.env.CCRECALL_RECALL_TELEMETRY_PATH
     process.env.CCRECALL_RECALL_TELEMETRY_PATH = logPath
     try {
-      recallQueryHandler(db, svc, { query: 'nonexistent-zzzz' })
+      recallQueryHandler(db, svc, { query: 'nonexistent-zzzz', projectId: 'proj-a' })
       const lines = readFileSync(logPath, 'utf8').trim().split('\n')
       expect(lines.length).toBe(1)
       const row = JSON.parse(lines[0])
@@ -122,6 +127,28 @@ describe('MCP recall_query handler', () => {
       if (original === undefined) delete process.env.CCRECALL_RECALL_TELEMETRY_PATH
       else process.env.CCRECALL_RECALL_TELEMETRY_PATH = original
     }
+  })
+
+  it('respects project isolation — only returns current-project memories', () => {
+    db.saveMemory({
+      sessionId: null,
+      messageId: null,
+      content: 'apache config lives in project alpha',
+      type: 'decision',
+      confidence: 1,
+      projectId: 'proj-a',
+    })
+    db.saveMemory({
+      sessionId: null,
+      messageId: null,
+      content: 'apache config lives in project beta',
+      type: 'decision',
+      confidence: 1,
+      projectId: 'proj-b',
+    })
+    const result = recallQueryHandler(db, svc, { query: 'apache', projectId: 'proj-a' })
+    expect(result.content[0].text).toContain('project alpha')
+    expect(result.content[0].text).not.toContain('project beta')
   })
 })
 
@@ -242,8 +269,8 @@ describe('MCP recall_save handler', () => {
   })
 
   it('persists memory queryable via recallQueryHandler', () => {
-    recallSaveHandler(db, { content: 'searchable via mcp tool', type: 'discovery' })
-    const result = recallQueryHandler(db, svc, { query: 'searchable' })
+    recallSaveHandler(db, { content: 'searchable via mcp tool', type: 'discovery', projectId: 'proj-a' })
+    const result = recallQueryHandler(db, svc, { query: 'searchable', projectId: 'proj-a' })
     expect(result.content[0].text).toContain('searchable via mcp tool')
     expect(result.content[0].text).toContain('[discovery]')
   })

--- a/tests/touch-integration.test.ts
+++ b/tests/touch-integration.test.ts
@@ -38,15 +38,15 @@ function accessCount(id: number): number {
 describe('recallQueryHandler — touch integration', () => {
   it('increments access_count for every returned memory', () => {
     const id1 = db.saveMemory({
-      sessionId: null, messageId: null, type: 'decision', content: 'alpha one',
+      sessionId: null, messageId: null, type: 'decision', content: 'alpha one', projectId: 'proj-a',
     })
     const id2 = db.saveMemory({
-      sessionId: null, messageId: null, type: 'decision', content: 'alpha two',
+      sessionId: null, messageId: null, type: 'decision', content: 'alpha two', projectId: 'proj-a',
     })
     expect(accessCount(id1)).toBe(0)
     expect(accessCount(id2)).toBe(0)
 
-    recallQueryHandler(db, svc, { query: 'alpha' })
+    recallQueryHandler(db, svc, { query: 'alpha', projectId: 'proj-a' })
 
     expect(accessCount(id1)).toBe(1)
     expect(accessCount(id2)).toBe(1)
@@ -54,28 +54,28 @@ describe('recallQueryHandler — touch integration', () => {
 
   it('does not touch memories that were not surfaced', () => {
     const surfacedId = db.saveMemory({
-      sessionId: null, messageId: null, type: 'decision', content: 'beta matched',
+      sessionId: null, messageId: null, type: 'decision', content: 'beta matched', projectId: 'proj-a',
     })
     const untouchedId = db.saveMemory({
-      sessionId: null, messageId: null, type: 'decision', content: 'gamma unmatched',
+      sessionId: null, messageId: null, type: 'decision', content: 'gamma unmatched', projectId: 'proj-a',
     })
-    recallQueryHandler(db, svc, { query: 'beta' })
+    recallQueryHandler(db, svc, { query: 'beta', projectId: 'proj-a' })
     expect(accessCount(surfacedId)).toBe(1)
     expect(accessCount(untouchedId)).toBe(0)
   })
 
   it('touches same memory twice on separate calls', () => {
     const id = db.saveMemory({
-      sessionId: null, messageId: null, type: 'decision', content: 'repeated',
+      sessionId: null, messageId: null, type: 'decision', content: 'repeated', projectId: 'proj-a',
     })
-    recallQueryHandler(db, svc, { query: 'repeated' })
-    recallQueryHandler(db, svc, { query: 'repeated' })
+    recallQueryHandler(db, svc, { query: 'repeated', projectId: 'proj-a' })
+    recallQueryHandler(db, svc, { query: 'repeated', projectId: 'proj-a' })
     expect(accessCount(id)).toBe(2)
   })
 
   it('noops on empty result set (touch never called)', () => {
     // No memories at all — handler should not throw.
-    expect(() => recallQueryHandler(db, svc, { query: 'nothing' })).not.toThrow()
+    expect(() => recallQueryHandler(db, svc, { query: 'nothing', projectId: 'proj-a' })).not.toThrow()
   })
 })
 


### PR DESCRIPTION
## What

The `recall_query` MCP tool was searching across **all** projects instead of the current one. This scopes it to the current project, matching the other three entry points.

## Root cause

`recall_query` was born in the MCP skeleton (`1238d98`) **before** the `project_id` mechanism existed. Scoping arrived in phase-4b (`c2b8262`); when query handlers were rewired in phase-4c (`14debcc`), `recall_context` picked up `projectId` but `recall_query` was missed — it called `db.queryMemories(query, limit)` with no `projectId`, hitting the no-filter (all-project) branch.

The project-scoped contract was an explicit early-development decision: cross-project visibility ("global") was rejected as unacceptable for an open-source tool — users expect project isolation. `recall_context` / `recall_save` / HTTP `/memory/query` all honor it; `recall_query` was the lone gap.

## Change

- `recallQueryInput`: add required `projectId` (`z.string().min(1)`, mirrors `recall_context` verbatim)
- `recallQueryHandler`: thread `projectId` into `db.queryMemories` + `appendRecallTelemetry` (telemetry `projectId` was hardcoded `null`, which also broke per-project grouping)
- tests: add cross-project isolation test (proj-a/proj-b — verified **red** when scoping is removed); scope existing `recall_query` + touch-integration tests to proj-a

## Side effect (intended)

Cross-project "accidental hits" disappear, so cold-rate figures may rise. But the prior baseline was inflated by this bug — post-fix numbers reflect true project-scoped recall.

## Quality gate (gogo)

- **Codex** adversarial review: 2 findings, both judged out-of-scope — no code change
- **Simplify**: diff already minimal (`projectId` mirrors `recall_context`)
- **Security** (OWASP Top 10:2025): A01 scoping logic / A05 SQL parameterization / A09 log injection / A10 fail-closed — all secure
- **Verify**: build / lint / test (599) all green

## Follow-up

Codex flagged that client-supplied `projectId` could be forged (server-side binding would be stronger). Pre-existing all-MCP design question, outside the current local / trusted-caller threat model. Tracked in #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
