### PR TITLE
fix(db): include global memories (project_id=NULL) in scoped recall queries

### DIFF
--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -1807,7 +1807,7 @@ export class Database {
             WHERE memories_fts MATCH ?
               AND (
                 (m.session_id IS NOT NULL AND s.project_id = ?) OR
-                (m.session_id IS NULL AND m.project_id = ?)
+                (m.session_id IS NULL AND (m.project_id = ? OR m.project_id IS NULL))
               )
             ORDER BY ${Database.EFFECTIVE_CONFIDENCE} DESC, rank, m.id DESC
             LIMIT ?
@@ -1859,7 +1859,7 @@ export class Database {
             WHERE ${where}
               AND (
                 (m.session_id IS NOT NULL AND s.project_id = ?) OR
-                (m.session_id IS NULL AND m.project_id = ?)
+                (m.session_id IS NULL AND (m.project_id = ? OR m.project_id IS NULL))
               )
             ORDER BY ${Database.EFFECTIVE_CONFIDENCE} DESC, m.created_at DESC, m.id DESC
             LIMIT ?
@@ -1925,7 +1925,7 @@ export class Database {
           AND m.type != 'query'
           AND (
             (m.session_id IS NOT NULL AND s.project_id = ?) OR
-            (m.session_id IS NULL AND m.project_id = ?)
+            (m.session_id IS NULL AND (m.project_id = ? OR m.project_id IS NULL))
           )
         ORDER BY m.created_at DESC
         LIMIT ?
@@ -1945,7 +1945,7 @@ export class Database {
           LEFT JOIN sessions s ON m.session_id = s.id
           WHERE (
               (m.session_id IS NOT NULL AND s.project_id = ?) OR
-              (m.session_id IS NULL AND m.project_id = ?)
+              (m.session_id IS NULL AND (m.project_id = ? OR m.project_id IS NULL))
             )
             ${excludeClause}
           ORDER BY ${Database.EFFECTIVE_CONFIDENCE} DESC, m.created_at DESC, m.id DESC

--- a/tests/memory-project-scope.test.ts
+++ b/tests/memory-project-scope.test.ts
@@ -117,16 +117,16 @@ describe('queryMemories — explicit scope predicate (session-backed vs manual)'
     db.saveMemory({ sessionId: null, messageId: null, type: 'preference', content: 'alpha global' })
   })
 
-  it('query with projectId=proj-A returns only A-scoped memories (session + manual)', () => {
+  it('query with projectId=proj-A returns A-scoped + global memories', () => {
     const results = db.queryMemories('alpha', 20, 'proj-A')
     const contents = results.map(r => r.content).sort()
-    expect(contents).toEqual(['alpha manualA', 'alpha sessA'])
+    expect(contents).toEqual(['alpha global', 'alpha manualA', 'alpha sessA'])
   })
 
-  it('query with projectId=proj-B returns only B-scoped memories', () => {
+  it('query with projectId=proj-B returns B-scoped + global memories', () => {
     const results = db.queryMemories('alpha', 20, 'proj-B')
     const contents = results.map(r => r.content).sort()
-    expect(contents).toEqual(['alpha manualB', 'alpha sessB'])
+    expect(contents).toEqual(['alpha global', 'alpha manualB', 'alpha sessB'])
   })
 
   it('query without projectId returns everything including global', () => {
@@ -134,10 +134,10 @@ describe('queryMemories — explicit scope predicate (session-backed vs manual)'
     expect(results.length).toBe(5)
   })
 
-  it('manual memory without projectId (global) is excluded from per-project queries', () => {
+  it('manual memory without projectId (global) is visible in per-project queries', () => {
     const a = db.queryMemories('alpha', 20, 'proj-A')
     const b = db.queryMemories('alpha', 20, 'proj-B')
-    expect(a.map(r => r.content)).not.toContain('alpha global')
-    expect(b.map(r => r.content)).not.toContain('alpha global')
+    expect(a.map(r => r.content)).toContain('alpha global')
+    expect(b.map(r => r.content)).toContain('alpha global')
   })
 })


### PR DESCRIPTION
## Summary

- Memories saved via `recall_save` without a `projectId` are cross-project knowledge (e.g. "Opus 4.7 has a parse bug", "always check schema before querying DB"). These were **structurally unreachable** in scoped queries because `NULL = ?` is always false in SQL — 15/31 memories affected, 8/10 cold memories caused by this alone.
- Add `OR m.project_id IS NULL` to the `session_id IS NULL` branch in all four query paths: `queryMemories`, `queryMemoriesFallback`, `getStartupMemories` Tier 1 + Tier 2. This treats manual NULL-project memories as **global** — visible from any project scope.
- Session-backed memories are unaffected (gated by `s.project_id = ?`).

## Evidence

- 15/15 NULL-project memories are manual (`session_id IS NULL`), zero orphans
- SQL + query log dual proof: FTS MATCH "opus" without filter → 3 hits; with project filter → 0
- Codex independent review confirmed approach + 6 gotchas addressed
- Multi-reviewer pipeline: Codex (4 findings) + Simplify (1) + Security (clean) — all adopted/resolved

## Test plan

- [x] Flip 4 test assertions: global memories now INCLUDED in per-project queries
- [x] 599/599 tests pass (baseline 599)
- [x] Build + lint clean
- [ ] 6/04 hit-rate report: verify cold-rate improvement with per-project breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)