### PR TITLE
docs: add roadmap section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,18 @@ The real trigger was simpler: I kept re-explaining the same architecture to Clau
 
 ---
 
+## Roadmap
+
+| Version | Theme | Status |
+|---------|-------|--------|
+| **v0.3.x** | Manual save, automatic recall — memories come from explicit `recall_save` calls; SessionStart hook and MCP tools inject them into future sessions | **Current** |
+| **v0.4.0** | Lower promotion friction — journal routing by entry type, partial promote with supersession tracking, CLI and hook surfacing of pending candidates | Planned |
+| **v0.5+** | Automatic memory — active decision detection during conversations, auto-promote above confidence threshold, closing the manual gap | Planned |
+
+Tracked in [GitHub Issues](https://github.com/tznthou/ccRecall/issues).
+
+---
+
 ## Changelog
 
 Release notes and version history live in [CHANGELOG.md](CHANGELOG.md). Every tagged version has a matching entry; the `Unreleased` section tracks what's landed on `main` but not yet published to npm.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -378,6 +378,18 @@ Anthropic Claude Code 團隊的 Thariq 在 2026 年 4 月[發表了 context 管�
 
 ---
 
+## 路線圖
+
+| 版本 | 主題 | 狀態 |
+|------|------|------|
+| **v0.3.x** | 手動存、自動召回——記憶來自明確的 `recall_save` 呼叫；SessionStart hook 和 MCP 工具在未來 session 注入 | **目前版本** |
+| **v0.4.0** | 降低 promote 摩擦——依 entry type 拆分 journal routing、支援 supersession 追蹤的 partial promote、CLI 和 hook 浮出 pending 候選 | 規劃中 |
+| **v0.5+** | 自動記憶——對話中主動偵測決策活體、信心值超門檻自動 promote、補上手動缺口 | 規劃中 |
+
+追蹤於 [GitHub Issues](https://github.com/tznthou/ccRecall/issues)。
+
+---
+
 ## 變更記錄
 
 版本更新與歷程記錄在 [CHANGELOG_ZH.md](CHANGELOG_ZH.md)。每個 tag 都有對應條目；`Unreleased` 段是已進 `main`、尚未發 npm 的改動。


### PR DESCRIPTION
## Summary

- Add a Roadmap table to both README.md and README_ZH.md
- Three milestones: v0.3.x (current), v0.4.0 (planned), v0.5+ (planned)
- Honest framing: v0.3.x is "manual save, automatic recall" — not "automatic memory"

Triggered by a framing audit that surfaced the gap between the README's "automation" narrative and the actual product state (automatic write pipeline throughput = 0; all 31 memories are manual `recall_save`).

## Test plan

- [ ] Verify roadmap renders correctly on GitHub (table format, links)
- [ ] Confirm no other README content was altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)