### PR TITLE
fix: integrity monitor uses a fresh connection to avoid false-positive malformed FTS5 reports

### DIFF
--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -918,12 +918,38 @@ export class Database {
     return { busy: rows[0].busy, checkpointed: rows[0].checkpointed }
   }
 
-  /** Run `PRAGMA integrity_check`. Returns `['ok']` on a clean DB, otherwise one
-   *  line per issue (e.g. 'row 48 missing from index idx_memories_access').
-   *  Read-only; safe to call on a live WAL DB. Consumed by IntegrityMonitor. */
+  /** Run `PRAGMA integrity_check` on a FRESH short-lived readonly connection
+   *  rather than this long-lived one. Returns `['ok']` on a clean DB, otherwise
+   *  one line per issue (e.g. 'row 48 missing from index idx_memories_access').
+   *  Consumed by IntegrityMonitor.
+   *
+   *  Why fresh: the daemon's long-lived connection accumulates page-cache state
+   *  that, under concurrent writes to the external-content FTS5 table
+   *  `memories_fts` (content='memories'), makes integrity_check report
+   *  false-positive 'malformed inverted index' while the on-disk index is
+   *  actually healthy. Confirmed 2026-06-16: a daemon restart cleared a
+   *  4.5h-persistent false→true, with the disk verified ok across 112
+   *  fresh-connection samples throughout. A fresh connection carries no such
+   *  drift, so the check reflects true on-disk state (it reads committed WAL
+   *  frames too, so nothing is missed). Opens readonly + one pragma + closes:
+   *  zero writes to the main DB.
+   *
+   *  :memory: / temp DBs cannot be opened readonly and have no shareable on-disk
+   *  file (a second connection would be a different empty DB), so fall back to
+   *  the live connection there — tests only; the daemon always uses a file path. */
   integrityCheck(): string[] {
-    const rows = this.db.pragma('integrity_check') as Array<{ integrity_check: string }>
-    return rows.map(r => r.integrity_check)
+    if (this.dbPath === ':memory:') {
+      const rows = this.db.pragma('integrity_check') as Array<{ integrity_check: string }>
+      return rows.map(r => r.integrity_check)
+    }
+    const fresh = new BetterSqlite3(this.dbPath, { readonly: true })
+    try {
+      fresh.pragma('busy_timeout = 5000')
+      const rows = fresh.pragma('integrity_check') as Array<{ integrity_check: string }>
+      return rows.map(r => r.integrity_check)
+    } finally {
+      fresh.close()
+    }
   }
 
   /** ⚠️ 測試專用：接受任意 SQL，禁止接到 IPC handler */

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -934,11 +934,13 @@ export class Database {
    *  frames too, so nothing is missed). Opens readonly + one pragma + closes:
    *  zero writes to the main DB.
    *
-   *  :memory: / temp DBs cannot be opened readonly and have no shareable on-disk
-   *  file (a second connection would be a different empty DB), so fall back to
-   *  the live connection there — tests only; the daemon always uses a file path. */
+   *  In-memory / temp DBs (better-sqlite3 sets db.memory=true for ':memory:',
+   *  '', and other anonymous forms) cannot be opened readonly and have no
+   *  shareable on-disk file — a second connection would be a different empty DB.
+   *  Fall back to the live connection there: tests only; the daemon always uses
+   *  a file path. */
   integrityCheck(): string[] {
-    if (this.dbPath === ':memory:') {
+    if (this.db.memory) {
       const rows = this.db.pragma('integrity_check') as Array<{ integrity_check: string }>
       return rows.map(r => r.integrity_check)
     }

--- a/tests/integrity-monitor.test.ts
+++ b/tests/integrity-monitor.test.ts
@@ -170,6 +170,17 @@ describe('Database.integrityCheck — fresh connection (S3-fresh)', () => {
     }
   })
 
+  it("anonymous temp DB (empty path) also falls back — db.memory covers it, not just ':memory:'", () => {
+    // Codex review: a `dbPath === ':memory:'` guard would miss '' / whitespace
+    // temp DBs (db.memory=true for all of them), throwing on the fresh readonly open.
+    const tmp = new Database('')
+    try {
+      expect(tmp.integrityCheck()).toEqual(['ok'])
+    } finally {
+      tmp.close()
+    }
+  })
+
   it('does not grow the main DB file (read-only — SSD-safe)', async () => {
     db.rawExec('CREATE TABLE probe(id INTEGER PRIMARY KEY, v TEXT)')
     db.checkpointTruncate()

--- a/tests/integrity-monitor.test.ts
+++ b/tests/integrity-monitor.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import path from 'node:path'
 import os from 'node:os'
-import { mkdtemp, rm, readdir, readFile } from 'node:fs/promises'
+import { mkdtemp, rm, readdir, readFile, stat } from 'node:fs/promises'
 import { Database } from '../src/core/database'
 import { IntegrityMonitor } from '../src/core/integrity-monitor'
 
@@ -141,5 +141,43 @@ describe('IntegrityMonitor — start() kicks off immediate tick', () => {
     await new Promise(resolve => setImmediate(resolve))
     expect(mon.getLastRecord()?.ok).toBe(true)
     mon.stop()
+  })
+})
+
+describe('Database.integrityCheck — fresh connection (S3-fresh)', () => {
+  // Root cause (2026-06-16 S2 experiment): the daemon's long-lived connection
+  // reports false-positive 'malformed inverted index' on external-content
+  // memories_fts under concurrent writes, while the on-disk index is healthy.
+  // integrityCheck() now runs on a fresh readonly connection to avoid that drift.
+  // Note: the drift itself cannot be reproduced in a unit test (it needs hours
+  // of daemon uptime + concurrent FTS writes); these tests cover the fresh-
+  // connection mechanics that the fix relies on. The drift-avoidance behaviour
+  // is evidenced by the S2 restart experiment, not by a unit test.
+
+  it('returns ok on a healthy file-backed DB (exercises the fresh readonly path)', () => {
+    // beforeEach builds a file-backed DB, so this goes through the fresh connection.
+    expect(db.integrityCheck()).toEqual(['ok'])
+  })
+
+  it(':memory: DB falls back to the live connection (readonly in-memory is impossible)', () => {
+    // Without the fallback, opening a fresh readonly :memory: throws
+    // "In-memory/temporary databases cannot be readonly".
+    const mem = new Database(':memory:')
+    try {
+      expect(mem.integrityCheck()).toEqual(['ok'])
+    } finally {
+      mem.close()
+    }
+  })
+
+  it('does not grow the main DB file (read-only — SSD-safe)', async () => {
+    db.rawExec('CREATE TABLE probe(id INTEGER PRIMARY KEY, v TEXT)')
+    db.checkpointTruncate()
+    const dbFile = path.join(tmpDir, 'test.db')
+    const before = await stat(dbFile)
+    db.integrityCheck()
+    db.integrityCheck()
+    const after = await stat(dbFile)
+    expect(after.size).toBe(before.size)
   })
 })


### PR DESCRIPTION
## Problem

The daemon ran `PRAGMA integrity_check` on its long-lived connection. Under concurrent writes to the external-content FTS5 table `memories_fts` (`content='memories'`), that connection accumulates page-cache state that makes the check report false-positive `malformed inverted index` — while the on-disk index is healthy. `/health` surfaced a persistent `lastIntegrityCheckOk: false` and the daemon wrote recurring alert files for at least 8 days.

## Root cause (verified by experiment)

The false reading lives in the long-lived connection, not on disk:

- 112 fresh-connection samples of the on-disk index were all `ok`; the FTS5-specific deep `integrity-check` PASSed on the same engine (better-sqlite3 3.49.2).
- A daemon restart cleared a 4.5h-persistent `false` → the first tick on the new connection read `true`, with the disk verified `ok` throughout. The corruption was never on disk.
- The false positive does **not** affect real queries: memory injection succeeded and recall hit rate stayed non-zero during the window.

This matches documented FTS5 behavior: external-content tables can report integrity issues from a connection whose cursor/cache state has drifted under concurrent writes.

## Fix

`Database.integrityCheck()` now opens a **fresh short-lived readonly connection** per check, which carries no such drift, so the result reflects true on-disk state. In-memory / temp DBs (`db.memory`) fall back to the live connection because they cannot be opened readonly.

- Zero extra writes (readonly; the main DB file is untouched — verified).
- A fresh connection still reads committed WAL frames, so nothing is missed.

## Tests

+4 tests covering the fresh-connection mechanics (healthy file DB, `:memory:` fallback, anonymous temp-DB fallback, no main-file growth). Full suite: **612 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
