### PR TITLE
fix: discard Haiku stray stdout in post-session extraction

### DIFF
--- a/scripts/post-session-extract.sh
+++ b/scripts/post-session-extract.sh
@@ -166,29 +166,29 @@ ${prompt}"
     budget_args=(--max-budget-usd "${CCRECALL_EXTRACT_MAX_BUDGET_USD:-0.50}")
   fi
 
-  # The extraction prompt tells Haiku to emit NO text — only its recall_save
-  # MCP tool calls carry the result, and those travel over MCP, never through
-  # stdout/stderr. Small models sometimes ignore that and print a stray summary
-  # anyway, which can even drift to an unrelated language (a Korean report was
-  # observed 2026-06-27). Such text never reaches the database; displaying it
-  # only risks alarming whoever sees the terminal. So capture BOTH streams
-  # (2>&1, no temp file = no leak on interrupt) into the telemetry log for
-  # later forensics and display NEITHER — the terminal shows only this
-  # wrapper's own status lines. Merging the streams also closes an
-  # observability gap: max-turns notices print to stdout, which the previous
-  # stderr-only capture silently dropped.
-  local extract_output extract_exit
-  extract_output=$(command claude -p \
+  # Haiku is prompted to emit NO text — only its recall_save MCP tool calls
+  # carry the result, and those travel over MCP, never through stdout. Small
+  # models sometimes ignore that and print a stray summary that can even drift
+  # to an unrelated language (a Korean report was observed 2026-06-27), which
+  # alarms whoever sees the terminal. So Haiku's stdout is discarded outright
+  # (1>/dev/null): it holds no extraction signal, and were it logged instead, a
+  # model that echoed transcript content could spill session secrets
+  # (GitHub/AWS/Bearer tokens, .env fragments, home paths) past the sk-ant-only
+  # scrubber. Only stderr — claude's own diagnostics — is captured, scrubbed,
+  # and logged. $? still reflects claude's exit (the assignment is the last
+  # command before it), and no temp file means no leak on interrupt.
+  local extract_stderr extract_exit
+  extract_stderr=$(command claude -p \
     --no-session-persistence \
     --model haiku \
     "${budget_args[@]}" \
     --max-turns 5 \
     --dangerously-skip-permissions \
-    "$full_prompt" 2>&1)
+    "$full_prompt" 2>&1 1>/dev/null)
   extract_exit=$?
   # Redact Anthropic API keys before they reach the telemetry log — claude
   # can echo the key in auth-error messages on the API-billing path.
-  extract_output=$(printf '%s' "$extract_output" | sed 's/sk-ant-[A-Za-z0-9_-]*/[REDACTED]/g' | head -c 2000)
+  extract_stderr=$(printf '%s' "$extract_stderr" | sed 's/sk-ant-[A-Za-z0-9_-]*/[REDACTED]/g' | head -c 2000)
 
   local extract_end
   extract_end=$(date +%s)
@@ -206,10 +206,10 @@ ${prompt}"
     --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --arg sid "$session_id" \
     --arg pid "$project_id" \
-    --arg output "$extract_output" \
+    --arg stderr "$extract_stderr" \
     --argjson exit "$extract_exit" \
     --argjson dur "$extract_duration" \
-    '{ts:$ts,sessionId:$sid,projectId:$pid,mode:"jsonl",exitCode:$exit,durationSec:$dur,output:$output}' \
+    '{ts:$ts,sessionId:$sid,projectId:$pid,mode:"jsonl",exitCode:$exit,durationSec:$dur,stderr:$stderr}' \
     >> "$CCRECALL_EXTRACT_LOG"
 
   return $claude_exit

--- a/scripts/post-session-extract.sh
+++ b/scripts/post-session-extract.sh
@@ -166,23 +166,29 @@ ${prompt}"
     budget_args=(--max-budget-usd "${CCRECALL_EXTRACT_MAX_BUDGET_USD:-0.50}")
   fi
 
-  # Capture stderr WITHOUT a temp file (no leak on interrupt/early exit):
-  # fd 3 holds the real stdout so the agent's output still streams to the
-  # terminal, while stderr is redirected into the command substitution.
-  local extract_stderr extract_exit
-  exec 3>&1
-  extract_stderr=$(command claude -p \
+  # The extraction prompt tells Haiku to emit NO text — only its recall_save
+  # MCP tool calls carry the result, and those travel over MCP, never through
+  # stdout/stderr. Small models sometimes ignore that and print a stray summary
+  # anyway, which can even drift to an unrelated language (a Korean report was
+  # observed 2026-06-27). Such text never reaches the database; displaying it
+  # only risks alarming whoever sees the terminal. So capture BOTH streams
+  # (2>&1, no temp file = no leak on interrupt) into the telemetry log for
+  # later forensics and display NEITHER — the terminal shows only this
+  # wrapper's own status lines. Merging the streams also closes an
+  # observability gap: max-turns notices print to stdout, which the previous
+  # stderr-only capture silently dropped.
+  local extract_output extract_exit
+  extract_output=$(command claude -p \
     --no-session-persistence \
     --model haiku \
     "${budget_args[@]}" \
     --max-turns 5 \
     --dangerously-skip-permissions \
-    "$full_prompt" 2>&1 1>&3)
+    "$full_prompt" 2>&1)
   extract_exit=$?
-  exec 3>&-
   # Redact Anthropic API keys before they reach the telemetry log — claude
   # can echo the key in auth-error messages on the API-billing path.
-  extract_stderr=$(printf '%s' "$extract_stderr" | sed 's/sk-ant-[A-Za-z0-9_-]*/[REDACTED]/g' | head -c 2000)
+  extract_output=$(printf '%s' "$extract_output" | sed 's/sk-ant-[A-Za-z0-9_-]*/[REDACTED]/g' | head -c 2000)
 
   local extract_end
   extract_end=$(date +%s)
@@ -200,10 +206,10 @@ ${prompt}"
     --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --arg sid "$session_id" \
     --arg pid "$project_id" \
-    --arg stderr "$extract_stderr" \
+    --arg output "$extract_output" \
     --argjson exit "$extract_exit" \
     --argjson dur "$extract_duration" \
-    '{ts:$ts,sessionId:$sid,projectId:$pid,mode:"jsonl",exitCode:$exit,durationSec:$dur,stderr:$stderr}' \
+    '{ts:$ts,sessionId:$sid,projectId:$pid,mode:"jsonl",exitCode:$exit,durationSec:$dur,output:$output}' \
     >> "$CCRECALL_EXTRACT_LOG"
 
   return $claude_exit

--- a/scripts/post-session-extract.sh
+++ b/scripts/post-session-extract.sh
@@ -186,9 +186,14 @@ ${prompt}"
     --dangerously-skip-permissions \
     "$full_prompt" 2>&1 1>/dev/null)
   extract_exit=$?
-  # Redact Anthropic API keys before they reach the telemetry log — claude
-  # can echo the key in auth-error messages on the API-billing path.
-  extract_stderr=$(printf '%s' "$extract_stderr" | sed 's/sk-ant-[A-Za-z0-9_-]*/[REDACTED]/g' | head -c 2000)
+  # Scrub common credential formats before stderr reaches the telemetry log.
+  # claude echoes its own key (sk-ant-) in auth errors, and any MCP server
+  # loaded for extraction (this runs with --dangerously-skip-permissions) can
+  # surface its own token in an init/auth failure. This is a best-effort
+  # denylist of common prefixes, not exhaustive — but stdout, the higher-risk
+  # stream where the model could echo transcript secrets, is already discarded
+  # entirely, so this only hardens claude's own diagnostics.
+  extract_stderr=$(printf '%s' "$extract_stderr" | sed -E 's/(sk-ant-|sk-proj-|ghp_|gho_|ghu_|ghs_|github_pat_|AKIA)[A-Za-z0-9_-]*/[REDACTED]/g' | head -c 2000)
 
   local extract_end
   extract_end=$(date +%s)


### PR DESCRIPTION
## What & why

Post-session memory extraction (`ccdm`) runs Haiku, which is prompted to emit **no** text — only `recall_save` MCP tool calls carry the result. But small models occasionally print a stray summary anyway, and one **drifted to Korean**, alarming the user. The wrapper was deliberately streaming Haiku's stdout to the terminal via `exec 3>&1` / `1>&3` fd juggling.

This discards Haiku's stdout entirely (`2>&1 1>/dev/null`): it carries no extraction signal (results travel over MCP, not stdout), so the terminal now shows only the wrapper's own status lines.

**Verified zero data corruption first**: the Korean was a stdout-only report. The two memories actually written that run were correct English, correctly scoped, and a full-table Hangul scan (`content GLOB '*[가-힣]*'`) returned **0** rows across the whole DB. This is a cosmetic/UX fix, not a data fix.

## gogo quality pipeline

| Stage | Commit | Result |
|-------|--------|--------|
| Codex Review | `5c632a2` | 1 finding (confidence 100): an interim version that merged stdout *into the telemetry log* could retain session secrets a model echoed from the transcript → reverted to discarding stdout outright |
| Simplify | — | SKIPPED — diff already minimal & idiomatic (`2>&1 1>/dev/null` order is load-bearing; fd-3 removal leaves no orphaned references) |
| Security | `e42cb43` | 1 Medium (OWASP A04/A09): stderr is still logged and extraction runs with `--dangerously-skip-permissions`, so a loaded MCP server's auth failure could surface a non-Anthropic token → broadened the credential scrub from `sk-ant-` only to also cover OpenAI / GitHub / AWS prefixes (best-effort denylist) |
| Final Verify | — | build ✅ · lint ✅ · test ✅ **612/612** |

> Note: `scripts/post-session-extract.sh` is a personal post-session workflow wrapper sourced from `.zshrc`; it is **not** part of the published npm package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
