### PR TITLE
Warn when ccrecall-extract launches in an untrusted workspace

### DIFF
--- a/scripts/post-session-extract.sh
+++ b/scripts/post-session-extract.sh
@@ -32,6 +32,24 @@ ccrecall-extract() {
   local project_id
   project_id=$(echo "$PWD" | sed 's|/|-|g')
 
+  # ── Trust pre-flight ──
+  # ccdm always launches claude with --dangerously-skip-permissions, which bypasses
+  # the tool-permission layer but never triggers the workspace trust dialog. A project
+  # only ever opened via ccdm therefore stays hasTrustDialogAccepted:false forever, and
+  # Claude Code silently ignores that project's .claude/settings.json permissions.allow
+  # + additionalDirectories. We deliberately do NOT auto-write trust into ~/.claude.json:
+  # ccRecall stays read-only toward Claude Code's state, and silently trusting whatever
+  # directory the user enters would defeat the trust gate's purpose. So we only surface
+  # the condition and let the user accept the dialog once via plain `claude`.
+  # Read the raw value (no `// empty`): jq's `//` treats the boolean false itself as a
+  # fallback trigger and would swallow the exact case we want to catch.
+  if [[ "$(jq -r --arg k "$PWD" '.projects[$k].hasTrustDialogAccepted' "$HOME/.claude.json" 2>/dev/null)" == "false" ]]; then
+    printf '\n⚠️  ccRecall: this workspace is not trusted. Claude Code will ignore its\n'
+    printf '    .claude/settings.json permissions (you may see "Ignoring ... permissions"\n'
+    printf '    warnings below). To fix, run plain `claude` here once — without ccdm —\n'
+    printf '    and accept the trust prompt.\n'
+  fi
+
   # ── Phase 1: Start session with memory injection ──
   CCRECALL_SESSION_START_STRATEGY=startup-v1 claude --dangerously-skip-permissions "$@"
   local claude_exit=$?

--- a/scripts/post-session-extract.sh
+++ b/scripts/post-session-extract.sh
@@ -33,9 +33,9 @@ ccrecall-extract() {
   project_id=$(echo "$PWD" | sed 's|/|-|g')
 
   # ── Trust pre-flight ──
-  # ccdm always launches claude with --dangerously-skip-permissions, which bypasses
-  # the tool-permission layer but never triggers the workspace trust dialog. A project
-  # only ever opened via ccdm therefore stays hasTrustDialogAccepted:false forever, and
+  # ccrecall-extract always launches claude with --dangerously-skip-permissions, which
+  # bypasses the tool-permission layer but never triggers the workspace trust dialog.
+  # A project only ever opened via this wrapper therefore stays hasTrustDialogAccepted:false forever, and
   # Claude Code silently ignores that project's .claude/settings.json permissions.allow
   # + additionalDirectories. We deliberately do NOT auto-write trust into ~/.claude.json:
   # ccRecall stays read-only toward Claude Code's state, and silently trusting whatever
@@ -46,7 +46,7 @@ ccrecall-extract() {
   if [[ "$(jq -r --arg k "$PWD" '.projects[$k].hasTrustDialogAccepted' "$HOME/.claude.json" 2>/dev/null)" == "false" ]]; then
     printf '\n⚠️  ccRecall: this workspace is not trusted. Claude Code will ignore its\n'
     printf '    .claude/settings.json permissions (you may see "Ignoring ... permissions"\n'
-    printf '    warnings below). To fix, run plain `claude` here once — without ccdm —\n'
+    printf '    warnings below). To fix, run plain `claude` here once — without this wrapper —\n'
     printf '    and accept the trust prompt.\n'
   fi
 


### PR DESCRIPTION
## What
Add a trust pre-flight to `ccrecall-extract`: when the current workspace has `hasTrustDialogAccepted:false`, warn that Claude Code will ignore the project's `.claude/settings.json` permissions, and point to the fix (accept the trust dialog once via plain `claude`).

## Why
`ccrecall-extract` always launches claude with `--dangerously-skip-permissions`, which bypasses the tool-permission layer but never triggers the workspace trust dialog. A project only ever opened via the extraction wrapper therefore stays `hasTrustDialogAccepted:false` forever, so Claude Code silently ignores its `permissions.allow` + `additionalDirectories`. This surfaces the otherwise-silent condition.

## Design
- **Read-only**: only reads the global Claude Code state file, never writes — preserves ccRecall's read-only stance toward Claude Code. Silently auto-trusting any directory the user enters would defeat the trust gate, which matters for anyone installing this wrapper from the public repo.
- Detects the raw boolean `false` (jq `// empty` would swallow `false` itself).

## Review
- **Cross-provider code review**: SKIPPED (sandbox constraint); single-source review surfaced only sub-threshold findings
- **Simplification pass**: no actionable findings
- **Security audit**: no Critical/High — jq `--arg` isolates `$PWD`, printf uses static format strings, read-only
- **Verification**: `bash -n` ✓ / `zsh -n` ✓ / vitest 612/612 (= baseline)

## Known limitation
Under symlinked paths (e.g. macOS `/tmp`→`/private/tmp`), `$PWD` may not match Claude Code's normalized project key → false negative (warning skipped). Fail-safe direction; claude's own native trust warning still appears.

🤖 Generated with Claude Code