### PR TITLE
fix: /session/last rescues fresh-session race with reindex fallback (#55)

### DIFF
--- a/scripts/post-session-extract.sh
+++ b/scripts/post-session-extract.sh
@@ -51,6 +51,11 @@ ccrecall-extract() {
   fi
 
   # ── Phase 1: Start session with memory injection ──
+  # launch_ts anchors /session/last's staleness gate (#55): the session that
+  # just closed must have messages after this instant, so an older session's
+  # endedAt < launch_ts marks it stale instead of being extracted again.
+  local launch_ts
+  launch_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   CCRECALL_SESSION_START_STRATEGY=startup-v1 claude --dangerously-skip-permissions "$@"
   local claude_exit=$?
 
@@ -67,7 +72,7 @@ ccrecall-extract() {
 
   # Fetch last session metadata for telemetry
   local session_meta
-  session_meta=$(curl -sf "http://127.0.0.1:${CCRECALL_PORT}/session/last?cwd=$(printf '%s' "$PWD" | jq -sRr @uri)" 2>/dev/null)
+  session_meta=$(curl -sf "http://127.0.0.1:${CCRECALL_PORT}/session/last?cwd=$(printf '%s' "$PWD" | jq -sRr @uri)&notBefore=${launch_ts}" 2>/dev/null)
   local session_id=""
   if [[ -n "$session_meta" ]]; then
     session_id=$(echo "$session_meta" | jq -r '.sessionId // empty' 2>/dev/null)

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -167,9 +167,24 @@ function validateCheckpointBody(
 
 const startTime = Date.now()
 
+/** Coalesces concurrent rescue calls onto one underlying run. The SessionEnd
+ *  hook (/session/end) and the extraction wrapper (/session/last) both fire
+ *  within the same session close — without this each miss stacks its own full
+ *  reindex. Unlike the watcher's single-flight guard this never DROPS a call:
+ *  joiners share the in-flight run's completion. A failed run clears the slot
+ *  so the next call retries. */
+export function coalesceRescue(run: () => Promise<void>): () => Promise<void> {
+  let inFlight: Promise<void> | null = null
+  return () => {
+    inFlight ??= run().finally(() => { inFlight = null })
+    return inFlight
+  }
+}
+
 export interface RequestHandlerOptions {
-  /** Called when /session/end sees a missing session — typically `() => runIndexer(db)`
-   *  — so a fresh-session hook can harvest after a forced reindex retry. */
+  /** Called when /session/end or /session/last sees a missing/stale session —
+   *  typically `coalesceRescue(() => runIndexer(db))` — so a fresh-session
+   *  caller can retry after a forced reindex. */
   rescueReindex?: () => Promise<void>
   /** Reported in /health; closure-captured so daemons installed from different
    *  package versions don't lie about which one is actually running. Defaults
@@ -228,8 +243,18 @@ export function createRequestHandler(
         return
       }
       const projectId = cwd.replace(/\//g, '-')
+      // Staleness gate (#55): the wrapper passes notBefore=<its launch time>.
+      // A session whose endedAt predates the launch cannot be the one that
+      // just closed — returning it would extract the WRONG session. endedAt,
+      // not startedAt, so resumed sessions (old start, fresh messages) pass.
+      const notBeforeMs = Date.parse(url.searchParams.get('notBefore') ?? '')
+      const isStale = (s: { endedAt: string | null }): boolean => {
+        if (Number.isNaN(notBeforeMs)) return false
+        const endedMs = s.endedAt ? Date.parse(s.endedAt) : NaN
+        return Number.isNaN(endedMs) || endedMs < notBeforeMs
+      }
       let last = db.getLastSession(projectId)
-      if (!last && opts.rescueReindex) {
+      if ((!last || isStale(last)) && opts.rescueReindex) {
         // Fresh-session race (#55): the extraction wrapper queries within
         // seconds of session close, before the watcher has indexed the fresh
         // JSONL. Same rescue as /session/end — reindex once and retry.
@@ -240,7 +265,7 @@ export function createRequestHandler(
         }
         last = db.getLastSession(projectId)
       }
-      if (!last) {
+      if (!last || isStale(last)) {
         sendJson(res, 404, { error: 'no sessions found for project' })
         return
       }

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -247,7 +247,13 @@ export function createRequestHandler(
       // A session whose endedAt predates the launch cannot be the one that
       // just closed — returning it would extract the WRONG session. endedAt,
       // not startedAt, so resumed sessions (old start, fresh messages) pass.
-      const notBeforeMs = Date.parse(url.searchParams.get('notBefore') ?? '')
+      // Clamp: the wrapper only ever sends "now". A spoofed far-future value
+      // would mark every session permanently stale, forcing a full reindex on
+      // each call (local DoS). Beyond a small clock-skew allowance, treat it
+      // like an unparseable value (gate disabled). NaN fails the comparison,
+      // so unparseable input stays NaN.
+      const rawNotBeforeMs = Date.parse(url.searchParams.get('notBefore') ?? '')
+      const notBeforeMs = rawNotBeforeMs <= Date.now() + 60_000 ? rawNotBeforeMs : NaN
       const isStale = (s: { endedAt: string | null }): boolean => {
         if (Number.isNaN(notBeforeMs)) return false
         const endedMs = s.endedAt ? Date.parse(s.endedAt) : NaN

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -228,7 +228,18 @@ export function createRequestHandler(
         return
       }
       const projectId = cwd.replace(/\//g, '-')
-      const last = db.getLastSession(projectId)
+      let last = db.getLastSession(projectId)
+      if (!last && opts.rescueReindex) {
+        // Fresh-session race (#55): the extraction wrapper queries within
+        // seconds of session close, before the watcher has indexed the fresh
+        // JSONL. Same rescue as /session/end — reindex once and retry.
+        try {
+          await opts.rescueReindex()
+        } catch (err) {
+          console.warn('[session-last] rescue reindex failed:', scrubErrorMessage(err))
+        }
+        last = db.getLastSession(projectId)
+      }
       if (!last) {
         sendJson(res, 404, { error: 'no sessions found for project' })
         return

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,7 @@ async function startDaemon(): Promise<void> {
   // shares (never drops) the run when /session/end and /session/last both miss
   // during the same session close.
   const server = createServer(db, {
-    rescueReindex: coalesceRescue(async () => { await runIndexer(db) }),
+    rescueReindex: coalesceRescue(() => runIndexer(db)),
     version: readPackageVersion(),
     dbPath: DB_PATH,
     integrityMonitor,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import path from 'node:path'
 import os from 'node:os'
 import { createServer } from './api/server.js'
+import { coalesceRescue } from './api/routes.js'
 import { Database } from './core/database.js'
 import { runIndexer } from './core/indexer.js'
 import { MemoryService } from './core/memory-service.js'
@@ -150,9 +151,11 @@ async function startDaemon(): Promise<void> {
 
   // Rescue reindex uses runIndexer directly (not watcher.runNow) so /session/end
   // gets deterministic execution instead of being dropped by watcher's single-
-  // flight guard when a scheduled scan is already inflight.
+  // flight guard when a scheduled scan is already inflight. coalesceRescue
+  // shares (never drops) the run when /session/end and /session/last both miss
+  // during the same session close.
   const server = createServer(db, {
-    rescueReindex: () => runIndexer(db),
+    rescueReindex: coalesceRescue(async () => { await runIndexer(db) }),
     version: readPackageVersion(),
     dbPath: DB_PATH,
     integrityMonitor,

--- a/tests/session-last-rescue.test.ts
+++ b/tests/session-last-rescue.test.ts
@@ -200,6 +200,17 @@ describe('GET /session/last — notBefore staleness (stale-session race)', () =>
     expect(status).toBe(200)
     expect((body as { sessionId: string }).sessionId).toBe(oldSessionId)
   })
+
+  it('ignores a far-future notBefore (rescue-forcing DoS guard)', async () => {
+    // A spoofed far-future timestamp would otherwise mark EVERY session
+    // permanently stale, forcing a full reindex on each call. The wrapper
+    // only ever sends "now", so anything beyond clock skew is invalid.
+    const { status, body } = await fetchJson(
+      `http://127.0.0.1:${port}/session/last?cwd=/test/rescue&notBefore=9999-01-01T00:00:00Z`,
+    )
+    expect(status).toBe(200)
+    expect((body as { sessionId: string }).sessionId).toBe(oldSessionId)
+  })
 })
 
 describe('coalesceRescue — concurrent rescues share one run', () => {

--- a/tests/session-last-rescue.test.ts
+++ b/tests/session-last-rescue.test.ts
@@ -7,6 +7,7 @@ import http from 'node:http'
 import { Database } from '../src/core/database.js'
 import { runIndexer } from '../src/core/indexer.js'
 import { createServer } from '../src/api/server.js'
+import { coalesceRescue } from '../src/api/routes.js'
 import { fetchJson } from './fixtures/helpers.js'
 
 // #55: the extraction wrapper queries /session/last within seconds of session
@@ -14,16 +15,29 @@ import { fetchJson } from './fixtures/helpers.js'
 // 2026-07-03: four skips each exactly ~2s before the session row appeared —
 // so /session/last needs the same rescue-reindex fallback /session/end has.
 //
+// The stale variant of the same race: when the project already has an older
+// indexed session, getLastSession happily returns it and the wrapper extracts
+// the WRONG session (6 duplicate extractions observed in telemetry). The
+// wrapper passes notBefore=<its launch time>; a session whose endedAt predates
+// it cannot be the one that just closed. endedAt (not startedAt) so resumed
+// sessions — old start, fresh messages — survive the check.
+//
 // Minimal indexable session — /session/last only needs the row to exist,
-// unlike /session/end's outcome-scoring fixtures.
-const simpleSession = [
-  { type: 'user', uuid: 'u1', timestamp: '2026-07-03T10:00:00Z', message: { role: 'user', content: 'hello' } },
-  { type: 'assistant', uuid: 'a1', timestamp: '2026-07-03T10:00:30Z', message: { role: 'assistant', content: 'world' } },
-]
+// unlike /session/end's outcome-scoring fixtures. Message uuids must be
+// unique per session: the indexer dedups messages by uuid across sessions
+// (resume support), so shared uuids silently empty the later session.
+function makeSession(prefix: string, t1: string, t2: string) {
+  return [
+    { type: 'user', uuid: `${prefix}-u1`, timestamp: t1, message: { role: 'user', content: 'hello' } },
+    { type: 'assistant', uuid: `${prefix}-a1`, timestamp: t2, message: { role: 'assistant', content: 'world' } },
+  ]
+}
+const simpleSession = makeSession('solo', '2026-07-03T10:00:00Z', '2026-07-03T10:00:30Z')
 
-// UUID-shaped id: the extraction wrapper validates the returned sessionId
-// against a UUID regex, so the fixture mirrors production ids.
+// UUID-shaped ids: the extraction wrapper validates the returned sessionId
+// against a UUID regex, so fixtures mirror production ids.
 const freshSessionId = 'aaaabbbb-cccc-4ddd-8eee-ffff00001111'
+const oldSessionId = '99998888-7777-4666-8555-444433332222'
 
 describe('GET /session/last — rescue reindex (fresh session race)', () => {
   let tmpDir: string
@@ -108,5 +122,124 @@ describe('GET /session/last — rescue reindex (fresh session race)', () => {
       `http://127.0.0.1:${port}/session/last?cwd=/test/rescue`,
     )
     expect(status).toBe(404)
+  })
+})
+
+describe('GET /session/last — notBefore staleness (stale-session race)', () => {
+  let tmpDir: string
+  let db: Database
+  let server: http.Server
+  let port: number
+  let projectsDir: string
+  let projectDir: string
+
+  async function listen(s: http.Server): Promise<number> {
+    return new Promise((resolve) => {
+      s.listen(0, '127.0.0.1', () => {
+        resolve((s.address() as { port: number }).port)
+      })
+    })
+  }
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ccrecall-last-stale-'))
+    projectsDir = path.join(tmpDir, 'projects')
+    projectDir = path.join(projectsDir, '-test-rescue')
+    await mkdir(projectDir, { recursive: true })
+
+    // Older session, indexed up front — the stale candidate.
+    await writeFile(
+      path.join(projectDir, `${oldSessionId}.jsonl`),
+      makeSession('old', '2026-07-03T08:00:00Z', '2026-07-03T08:30:00Z')
+        .map(l => JSON.stringify(l)).join('\n'),
+    )
+    db = new Database(path.join(tmpDir, 'test.db'))
+    await runIndexer(db, undefined, projectsDir)
+
+    // Fresh session written AFTER the initial index — unindexed, like the
+    // JSONL the watcher has not picked up yet.
+    await writeFile(
+      path.join(projectDir, `${freshSessionId}.jsonl`),
+      makeSession('fresh', '2026-07-03T10:00:00Z', '2026-07-03T10:00:30Z')
+        .map(l => JSON.stringify(l)).join('\n'),
+    )
+
+    server = createServer(db, {
+      rescueReindex: () => runIndexer(db, undefined, projectsDir),
+    })
+    port = await listen(server)
+  })
+
+  afterEach(async () => {
+    server.close()
+    db.close()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('stale hit triggers rescue and returns the fresh session, not the old one', async () => {
+    // Wrapper launched at 09:00 — the 08:30-ended session cannot be "the one
+    // that just closed", even though getLastSession would happily return it.
+    const { status, body } = await fetchJson(
+      `http://127.0.0.1:${port}/session/last?cwd=/test/rescue&notBefore=2026-07-03T09:00:00Z`,
+    )
+    expect(status).toBe(200)
+    expect((body as { sessionId: string }).sessionId).toBe(freshSessionId)
+  })
+
+  it('returns 404 when rescue still finds nothing fresh enough', async () => {
+    const { status } = await fetchJson(
+      `http://127.0.0.1:${port}/session/last?cwd=/test/rescue&notBefore=2026-07-03T12:00:00Z`,
+    )
+    expect(status).toBe(404)
+  })
+
+  it('without notBefore keeps the old behavior: returns the latest indexed session', async () => {
+    const { status, body } = await fetchJson(
+      `http://127.0.0.1:${port}/session/last?cwd=/test/rescue`,
+    )
+    expect(status).toBe(200)
+    expect((body as { sessionId: string }).sessionId).toBe(oldSessionId)
+  })
+
+  it('ignores an unparseable notBefore and returns the latest indexed session', async () => {
+    const { status, body } = await fetchJson(
+      `http://127.0.0.1:${port}/session/last?cwd=/test/rescue&notBefore=not-a-date`,
+    )
+    expect(status).toBe(200)
+    expect((body as { sessionId: string }).sessionId).toBe(oldSessionId)
+  })
+})
+
+describe('coalesceRescue — concurrent rescues share one run', () => {
+  it('two concurrent callers trigger a single underlying run', async () => {
+    let runs = 0
+    let release!: () => void
+    const gate = new Promise<void>(resolve => { release = resolve })
+    const rescue = coalesceRescue(async () => { runs++; await gate })
+
+    const p1 = rescue()
+    const p2 = rescue()
+    release()
+    await Promise.all([p1, p2])
+    expect(runs).toBe(1)
+  })
+
+  it('a new call after completion runs again', async () => {
+    let runs = 0
+    const rescue = coalesceRescue(async () => { runs++ })
+    await rescue()
+    await rescue()
+    expect(runs).toBe(2)
+  })
+
+  it('a failed run clears the slot so the next call retries', async () => {
+    let runs = 0
+    const rescue = coalesceRescue(async () => {
+      runs++
+      if (runs === 1) throw new Error('boom')
+    })
+    await expect(rescue()).rejects.toThrow('boom')
+    await rescue()
+    expect(runs).toBe(2)
   })
 })

--- a/tests/session-last-rescue.test.ts
+++ b/tests/session-last-rescue.test.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import http from 'node:http'
+import { Database } from '../src/core/database.js'
+import { runIndexer } from '../src/core/indexer.js'
+import { createServer } from '../src/api/server.js'
+import { fetchJson } from './fixtures/helpers.js'
+
+// #55: the extraction wrapper queries /session/last within seconds of session
+// close, before the watcher/indexer has picked up the fresh JSONL. Observed
+// 2026-07-03: four skips each exactly ~2s before the session row appeared —
+// so /session/last needs the same rescue-reindex fallback /session/end has.
+//
+// Minimal indexable session — /session/last only needs the row to exist,
+// unlike /session/end's outcome-scoring fixtures.
+const simpleSession = [
+  { type: 'user', uuid: 'u1', timestamp: '2026-07-03T10:00:00Z', message: { role: 'user', content: 'hello' } },
+  { type: 'assistant', uuid: 'a1', timestamp: '2026-07-03T10:00:30Z', message: { role: 'assistant', content: 'world' } },
+]
+
+// UUID-shaped id: the extraction wrapper validates the returned sessionId
+// against a UUID regex, so the fixture mirrors production ids.
+const freshSessionId = 'aaaabbbb-cccc-4ddd-8eee-ffff00001111'
+
+describe('GET /session/last — rescue reindex (fresh session race)', () => {
+  let tmpDir: string
+  let db: Database
+  let server: http.Server
+  let port: number
+  let projectsDir: string
+
+  async function listen(s: http.Server): Promise<number> {
+    return new Promise((resolve) => {
+      s.listen(0, '127.0.0.1', () => {
+        resolve((s.address() as { port: number }).port)
+      })
+    })
+  }
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ccrecall-last-rescue-'))
+    projectsDir = path.join(tmpDir, 'projects')
+    const projectDir = path.join(projectsDir, '-test-rescue')
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(
+      path.join(projectDir, `${freshSessionId}.jsonl`),
+      simpleSession.map(l => JSON.stringify(l)).join('\n'),
+    )
+
+    db = new Database(path.join(tmpDir, 'test.db'))
+    // Intentionally skip runIndexer here — simulate the race where the
+    // wrapper queries before the daemon has indexed the fresh JSONL.
+
+    server = createServer(db, {
+      rescueReindex: () => runIndexer(db, undefined, projectsDir),
+    })
+    port = await listen(server)
+  })
+
+  afterEach(async () => {
+    server.close()
+    db.close()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('rescues a fresh session: reindexes on miss then returns it', async () => {
+    expect(db.getLastSession('-test-rescue')).toBeNull()
+
+    const { status, body } = await fetchJson(
+      `http://127.0.0.1:${port}/session/last?cwd=/test/rescue`,
+    )
+    expect(status).toBe(200)
+    expect((body as { sessionId: string }).sessionId).toBe(freshSessionId)
+    expect(db.getLastSession('-test-rescue')).not.toBeNull()
+  })
+
+  it('still returns 404 if rescue cannot locate any session for the project', async () => {
+    const { status } = await fetchJson(
+      `http://127.0.0.1:${port}/session/last?cwd=/nonexistent/place`,
+    )
+    expect(status).toBe(404)
+  })
+
+  it('rescue failure does not crash: returns 404 if project still has no session', async () => {
+    server.close()
+    await new Promise(resolve => server.on('close', resolve))
+    server = createServer(db, {
+      rescueReindex: async () => { throw new Error('indexer failed') },
+    })
+    port = await listen(server)
+
+    const { status } = await fetchJson(
+      `http://127.0.0.1:${port}/session/last?cwd=/test/rescue`,
+    )
+    expect(status).toBe(404)
+  })
+
+  it('without a rescueReindex option, a fresh session still 404s (no fallback)', async () => {
+    server.close()
+    await new Promise(resolve => server.on('close', resolve))
+    server = createServer(db)
+    port = await listen(server)
+
+    const { status } = await fetchJson(
+      `http://127.0.0.1:${port}/session/last?cwd=/test/rescue`,
+    )
+    expect(status).toBe(404)
+  })
+})

--- a/tests/session-last-rescue.test.ts
+++ b/tests/session-last-rescue.test.ts
@@ -39,20 +39,20 @@ const simpleSession = makeSession('solo', '2026-07-03T10:00:00Z', '2026-07-03T10
 const freshSessionId = 'aaaabbbb-cccc-4ddd-8eee-ffff00001111'
 const oldSessionId = '99998888-7777-4666-8555-444433332222'
 
+async function listen(s: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    s.listen(0, '127.0.0.1', () => {
+      resolve((s.address() as { port: number }).port)
+    })
+  })
+}
+
 describe('GET /session/last — rescue reindex (fresh session race)', () => {
   let tmpDir: string
   let db: Database
   let server: http.Server
   let port: number
   let projectsDir: string
-
-  async function listen(s: http.Server): Promise<number> {
-    return new Promise((resolve) => {
-      s.listen(0, '127.0.0.1', () => {
-        resolve((s.address() as { port: number }).port)
-      })
-    })
-  }
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ccrecall-last-rescue-'))
@@ -132,14 +132,6 @@ describe('GET /session/last — notBefore staleness (stale-session race)', () =>
   let port: number
   let projectsDir: string
   let projectDir: string
-
-  async function listen(s: http.Server): Promise<number> {
-    return new Promise((resolve) => {
-      s.listen(0, '127.0.0.1', () => {
-        resolve((s.address() as { port: number }).port)
-      })
-    })
-  }
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ccrecall-last-stale-'))


### PR DESCRIPTION
## Problem

Post-session extraction skips with `no-session-id` jumped from **3%** (4 skips / 132 runs, 6/05–6/26) to **23.7%** (9 skips / 38 runs, 6/27–7/03). Each skip is a real loss — spot-checked sessions had 229/559/848 messages and their memories were never extracted.

## Root cause (#55, now with hard evidence)

The extraction wrapper queries `GET /session/last` within seconds of session close, before the watcher/indexer has picked up the fresh JSONL. Four skips on 7/01–7/03 each logged **exactly ~2s before** the session row's `created_at` appeared in the DB:

| session | close→skip | skip → row indexed |
|---|---|---|
| 3da1e10a | 11:16:44 | +2s (11:16:46) |
| 0ed15317 | 00:53:59 | +2s (00:54:01) |
| 041e568d | 08:48:55 | +2s (08:48:57) |
| 425fffc2 | 09:59:51 | +2s (09:59:53) |

`/session/end` already has a `rescueReindex` fallback for exactly this race (routes.ts:506); `/session/last` returned a bare 404.

## Fix

On a `getLastSession` miss, run one rescue reindex and retry before 404 — mirroring `/session/end`. Rescue failure degrades to the previous behavior (404, no crash).

## Tests

- `tests/session-last-rescue.test.ts` (new, 4 cases): rescue-then-200, rescue-miss-404, rescue-throw-404, no-option-404
- Full suite: **616/616 green**, lint clean, build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)