### PR TITLE
fix: prevent compression from collapsing sibling memories into duplicates

### DIFF
--- a/src/core/compression.ts
+++ b/src/core/compression.ts
@@ -10,7 +10,9 @@ import { scrubErrorMessage } from './log-safe.js'
  * based on age, access, and effective confidence gates. Session-backed memories
  * sample `sessions.summary_text`/`intent_text` so L1/L2 content is derived from
  * the original source rather than repeatedly truncating a truncated string.
- * Manual memories and orphaned rows fall back to syntactic truncation.
+ * Manual memories, orphaned rows, and memories sharing a session with sibling
+ * memories (summary_text describes the whole session, not one memory within
+ * it) fall back to syntactic truncation.
  *
  * Auto-delete at L2 applies only to session-backed memories (`session_id IS NOT NULL`)
  * — a user's manual memory is treated as an explicit intent and capped at L2.
@@ -59,9 +61,11 @@ export function truncate(text: string, maxChars: number): string {
 
 function deriveL1Content(c: CompressionCandidate): string {
   // Session-backed: prefer the indexer-written summary as the compressed form.
-  // When the session row is missing (deleted manually, or pre-index race) fall
-  // through to syntactic truncation — matching the manual-memory path.
-  if (c.sessionId) {
+  // When the session row is missing (deleted manually, or pre-index race), or
+  // another memory shares this sessionId, fall through to syntactic truncation
+  // — summary_text is session-wide, so reusing it across sibling memories would
+  // collapse their distinct content into byte-identical duplicates.
+  if (c.sessionId && !c.hasSiblingMemories) {
     const summary = c.summaryText?.trim()
     if (summary) return summary
   }
@@ -69,7 +73,7 @@ function deriveL1Content(c: CompressionCandidate): string {
 }
 
 function deriveL2Content(c: CompressionCandidate): string {
-  if (c.sessionId) {
+  if (c.sessionId && !c.hasSiblingMemories) {
     const intent = c.intentText?.trim()
     if (intent) return intent
     const summary = c.summaryText?.trim()

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -2208,10 +2208,9 @@ export class Database {
    *  (manual scrub of ~/.claude) still surface; the pipeline detects the NULL
    *  summary and falls back to syntactic truncation, matching manual memories.
    *
-   *  `session_memory_counts` feeds `has_sibling_memories`: a session that produced
-   *  more than one memory must not let them share `summary_text` as compressed
-   *  content, or they collapse into byte-identical duplicates (see
-   *  hasSiblingMemories on CompressionCandidate). */
+   *  `session_memory_counts` counts memories per session so `has_sibling_memories`
+   *  can flag sessions with >1 memory (see hasSiblingMemories on
+   *  CompressionCandidate for why that matters). */
   getCompressionCandidates(limit: number): CompressionCandidate[] {
     // Only return rows that match at least one level's transition gates — ORDER
     // BY id ASC + LIMIT would otherwise stall on the first `batchSize` of rows

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -143,6 +143,7 @@ interface CompressionCandidateRow {
   summary_text: string | null
   intent_text: string | null
   session_exists: number
+  has_sibling_memories: number
 }
 
 /** Phase 4d: normalised shape consumed by the compression pipeline. */
@@ -160,6 +161,11 @@ export interface CompressionCandidate {
    *  False for manual memories (sessionId is null) or orphaned rows. Used by
    *  the compression pipeline to block irreversible auto-delete of orphans. */
   sessionExists: boolean
+  /** True when another memory shares this row's `sessionId`. `summary_text`/
+   *  `intent_text` describe the whole session, not one memory within it — reusing
+   *  them across siblings would collapse distinct memories into duplicates. The
+   *  pipeline falls back to per-memory truncation whenever this is true. */
+  hasSiblingMemories: boolean
 }
 
 function mapMemoryRow(r: MemoryRow): Memory {
@@ -2200,7 +2206,12 @@ export class Database {
    *
    *  LEFT JOIN sessions so session-backed memories whose session row was deleted
    *  (manual scrub of ~/.claude) still surface; the pipeline detects the NULL
-   *  summary and falls back to syntactic truncation, matching manual memories. */
+   *  summary and falls back to syntactic truncation, matching manual memories.
+   *
+   *  `session_memory_counts` feeds `has_sibling_memories`: a session that produced
+   *  more than one memory must not let them share `summary_text` as compressed
+   *  content, or they collapse into byte-identical duplicates (see
+   *  hasSiblingMemories on CompressionCandidate). */
   getCompressionCandidates(limit: number): CompressionCandidate[] {
     // Only return rows that match at least one level's transition gates — ORDER
     // BY id ASC + LIMIT would otherwise stall on the first `batchSize` of rows
@@ -2212,18 +2223,26 @@ export class Database {
     // deleting an orphan is irreversible data loss since the source JSONL is
     // already gone.
     const rows = this.db.prepare(`
+      WITH session_memory_counts AS (
+        SELECT session_id, COUNT(*) AS memory_count
+        FROM memories
+        WHERE session_id IS NOT NULL
+        GROUP BY session_id
+      )
       SELECT id, session_id, content, compression_level, access_count,
              age_days, effective_confidence, summary_text, intent_text,
-             session_exists
+             session_exists, has_sibling_memories
       FROM (
         SELECT
           m.id, m.session_id, m.content, m.compression_level, m.access_count,
           (julianday('now') - julianday(COALESCE(m.last_accessed, m.created_at))) AS age_days,
           ${Database.EFFECTIVE_CONFIDENCE} AS effective_confidence,
           s.summary_text, s.intent_text,
-          CASE WHEN s.id IS NULL THEN 0 ELSE 1 END AS session_exists
+          CASE WHEN s.id IS NULL THEN 0 ELSE 1 END AS session_exists,
+          CASE WHEN COALESCE(smc.memory_count, 1) > 1 THEN 1 ELSE 0 END AS has_sibling_memories
         FROM memories m
         LEFT JOIN sessions s ON m.session_id = s.id
+        LEFT JOIN session_memory_counts smc ON smc.session_id = m.session_id
       )
       WHERE
         (compression_level = 0 AND age_days >= 7 AND access_count < 2 AND effective_confidence < 0.5)
@@ -2244,6 +2263,7 @@ export class Database {
       summaryText: r.summary_text,
       intentText: r.intent_text,
       sessionExists: r.session_exists === 1,
+      hasSiblingMemories: r.has_sibling_memories === 1,
     }))
   }
 

--- a/tests/compression.test.ts
+++ b/tests/compression.test.ts
@@ -182,7 +182,7 @@ describe('planTransition() — L1 content source', () => {
     if (a.kind === 'compress') expect(a.newContent.endsWith('...')).toBe(true)
   })
 
-  it('falls back to truncation when the session has sibling memories (prevents duplicate collapse)', () => {
+  it('falls back to truncation when the session has sibling memories (prevents duplicate collapse) — L1', () => {
     const a = planTransition(candidate({
       ageDays: 10, effectiveConfidence: 0.3, sessionId: 'sess-1', hasSiblingMemories: true,
       summaryText: 'shared session summary',
@@ -233,7 +233,7 @@ describe('planTransition() — L2 content source', () => {
     }
   })
 
-  it('falls back to truncation when the session has sibling memories (prevents duplicate collapse)', () => {
+  it('falls back to truncation when the session has sibling memories (prevents duplicate collapse) — L2', () => {
     const a = planTransition(candidate({
       compressionLevel: 1, ageDays: 40, sessionId: 'sess-1', hasSiblingMemories: true,
       intentText: 'shared intent', summaryText: 'shared summary',

--- a/tests/compression.test.ts
+++ b/tests/compression.test.ts
@@ -37,6 +37,7 @@ function candidate(overrides: Partial<CompressionCandidate> = {}): CompressionCa
     summaryText: null,
     intentText: null,
     sessionExists: false,
+    hasSiblingMemories: false,
     ...overrides,
   }
 }
@@ -180,6 +181,19 @@ describe('planTransition() — L1 content source', () => {
     expect(a.kind).toBe('compress')
     if (a.kind === 'compress') expect(a.newContent.endsWith('...')).toBe(true)
   })
+
+  it('falls back to truncation when the session has sibling memories (prevents duplicate collapse)', () => {
+    const a = planTransition(candidate({
+      ageDays: 10, effectiveConfidence: 0.3, sessionId: 'sess-1', hasSiblingMemories: true,
+      summaryText: 'shared session summary',
+      content: "this memory's own distinct content " + 'x'.repeat(150),
+    }))
+    expect(a.kind).toBe('compress')
+    if (a.kind === 'compress') {
+      expect(a.newContent).not.toBe('shared session summary')
+      expect(a.newContent.startsWith("this memory's own distinct content")).toBe(true)
+    }
+  })
 })
 
 describe('planTransition() — L2 content source', () => {
@@ -216,6 +230,19 @@ describe('planTransition() — L2 content source', () => {
     if (a.kind === 'compress') {
       expect(a.newContent.endsWith('...')).toBe(true)
       expect(a.newContent.length).toBeLessThanOrEqual(83)
+    }
+  })
+
+  it('falls back to truncation when the session has sibling memories (prevents duplicate collapse)', () => {
+    const a = planTransition(candidate({
+      compressionLevel: 1, ageDays: 40, sessionId: 'sess-1', hasSiblingMemories: true,
+      intentText: 'shared intent', summaryText: 'shared summary',
+      content: "this memory's own distinct content " + 'y'.repeat(100),
+    }))
+    expect(a.kind).toBe('compress')
+    if (a.kind === 'compress') {
+      expect(a.newContent).not.toBe('shared intent')
+      expect(a.newContent.startsWith("this memory's own distinct content")).toBe(true)
     }
   })
 })
@@ -361,6 +388,35 @@ describe('CompressionPipeline.runOnce() — end-to-end', () => {
       `SELECT content FROM memories WHERE id = ${id}`,
     )[0]
     expect(row.content).toBe('canonical summary')
+  })
+
+  it('two memories sharing a session compress to DISTINCT content, not collapsed duplicates', () => {
+    db.upsertProject('p4', 'P')
+    db.rawExec(`
+      INSERT INTO sessions (id, project_id, file_path, summary_text, intent_text)
+      VALUES ('s4', 'p4', '/tmp/s4.jsonl', 'shared session summary', 'shared session intent')
+    `)
+    db.saveMemory({
+      sessionId: 's4', messageId: null, type: 'discovery',
+      content: 'first distinct discovery ' + 'a'.repeat(200), confidence: 0.2,
+    })
+    db.saveMemory({
+      sessionId: 's4', messageId: null, type: 'pattern',
+      content: 'second distinct pattern ' + 'b'.repeat(200), confidence: 0.2,
+    })
+    db.rawExec(`UPDATE memories SET created_at = datetime('now', '-10 days') WHERE session_id = 's4'`)
+
+    const stats = pipe.runOnce()
+    expect(stats.compressed).toBe(2)
+
+    const rows = db.rawAll<{ id: number; content: string }>(
+      `SELECT id, content FROM memories WHERE session_id = 's4' ORDER BY id`,
+    )
+    expect(rows[0].content).not.toBe(rows[1].content)
+    expect(rows[0].content).not.toBe('shared session summary')
+    expect(rows[1].content).not.toBe('shared session summary')
+    expect(rows[0].content.startsWith('first distinct discovery')).toBe(true)
+    expect(rows[1].content.startsWith('second distinct pattern')).toBe(true)
   })
 
   it('session-backed memory with deleted session row falls back to truncation', () => {


### PR DESCRIPTION
## Problem

`deriveL1Content`/`deriveL2Content` replace a memory's content with the owning session's `summary_text`/`intent_text` when compressing. When one session produced **multiple** memories (the norm since post-session extraction: 86% of memory-bearing sessions), every sibling gets rewritten to the same session-wide string — collapsing distinct distilled facts into byte-identical duplicates. The UPDATE is destructive; original content is gone from the DB.

Confirmed in production: 23 rows across 7 sessions already collapsed (`content = sessions.summary_text` verified byte-for-byte), all of them keyed extraction memories. Introduced by `89be9ad5` (2026-04-17), surfaced only after post-session extraction made multi-memory sessions the common case.

## Fix

`getCompressionCandidates` now computes `has_sibling_memories` via a `session_memory_counts` CTE. `deriveL1Content`/`deriveL2Content` only short-circuit to the session summary when the memory is the session's **only** memory; siblings fall back to syntactic truncation of their own content, preserving distinctness.

## Tests

- 2 unit tests (`planTransition` L1/L2): sibling candidates truncate own content, never adopt shared summary
- 1 integration test (`CompressionPipeline.runOnce()` on a real DB): two memories sharing a session compress to distinct content
- 627/627 passing

GoGo pipeline: Codex review (2 findings assessed, both no-fix with rationale) / Simplify (2 fixes applied) / Security lint (OWASP A05+A08+A10, zero findings) / Build+TypeCheck+Lint+Test all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)